### PR TITLE
New Tests and Contract Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,24 @@ To remove a guard, instead of baking in the delay mechanism within the guard con
 - Once the delay is over, we can apply the policy using `applyConfiguration(...)` and also remove the Guard (we can use MultiSend for the same to do in a single transaction).
 
 Note: If the Safe reactivates the guard, this policy should be removed (can be done without any delay with `configureImmediately(...)` before the guard is enabled) 
+
+## Testing
+
+Run the test suite:
+```bash
+npm test
+```
+
+Run gas benchmarks:
+```bash
+npm run test:bench
+```
+
+## Deployment
+
+Deploy contracts:
+```bash
+npm run deploy -- <network>
+```
+
+Note: Ensure proper configuration of delay parameters based on your security requirements. 

--- a/contracts/core/PolicyEngine.sol
+++ b/contracts/core/PolicyEngine.sol
@@ -154,10 +154,12 @@ abstract contract PolicyEngine is IPolicyEngine {
     ) internal {
         // Creating access selector for a policy
         AccessSelector.T access = AccessSelector.create(target, selector, operation);
-        $policies[safe][access] = policy;
 
         // Configuring policy
         require(IPolicy(policy).configure(safe, access, data), PolicyConfigurationFailed());
+
+        // Update the policy mapping
+        $policies[safe][access] = policy;
 
         emit PolicyConfirmed(safe, target, selector, operation, policy, data);
     }

--- a/contracts/policies/CoSignerPolicy.sol
+++ b/contracts/policies/CoSignerPolicy.sol
@@ -11,11 +11,16 @@ import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/Signa
  * @dev Ensure a Safe transaction has been co-signed.
  */
 contract CoSignerPolicy is IPolicy {
+    /**
+     * @dev Mapping of cosigners for each Safe and access selector.
+     */
+    // solhint-disable-next-line private-vars-leading-underscore
     mapping(address policyGuard => mapping(address safe => mapping(AccessSelector.T access => address cosigner)))
-        public cosigners;
+        private $cosigners;
 
     error Unauthorized();
     error InvalidSelector();
+    error NoCosignerConfigured();
 
     function checkTransaction(
         address safe,
@@ -43,7 +48,8 @@ contract CoSignerPolicy is IPolicy {
         );
 
         // Retrieve the co-signer configured for the Safe account.
-        address cosigner = cosigners[msg.sender][safe][access];
+        address cosigner = $cosigners[msg.sender][safe][access];
+        if (cosigner == address(0)) revert NoCosignerConfigured();
 
         bool validSignature = SignatureChecker.isValidSignatureNow(cosigner, safeTxHash, context);
         require(validSignature, Unauthorized());
@@ -56,7 +62,17 @@ contract CoSignerPolicy is IPolicy {
      */
     function configure(address safe, AccessSelector.T access, bytes memory data) external override returns (bool) {
         address cosigner = abi.decode(data, (address));
-        cosigners[msg.sender][safe][access] = cosigner;
+        $cosigners[msg.sender][safe][access] = cosigner;
         return true;
+    }
+
+    /**
+     * @notice Get the co-signer for a given Safe and access selector.
+     * @param safe The address of the Safe.
+     * @param access The access selector.
+     * @return cosigner The address of the co-signer.
+     */
+    function getCoSigner(address safe, AccessSelector.T access) external view returns (address cosigner) {
+        cosigner = $cosigners[msg.sender][safe][access];
     }
 }

--- a/contracts/policies/ERC20ApprovePolicy.sol
+++ b/contracts/policies/ERC20ApprovePolicy.sol
@@ -22,6 +22,9 @@ contract ERC20ApprovePolicy is IPolicy {
         bool allowed;
     }
 
+    /**
+     * @dev Mapping of spenders for each Safe and token.
+     */
     // solhint-disable-next-line private-vars-leading-underscore
     mapping(address policyGuard => mapping(address safe => mapping(address token => mapping(address spender => bool))))
         private $spenders;
@@ -88,5 +91,22 @@ contract ERC20ApprovePolicy is IPolicy {
             $spenders[msg.sender][safe][target][spenderList[i].spender] = spenderList[i].allowed;
         }
         return true;
+    }
+
+    /**
+     * @notice Check if a spender is allowed for a specific Safe and token.
+     * @param policyGuard The address of the policy guard.
+     * @param safe The Safe address.
+     * @param token The token address.
+     * @param spender The spender address.
+     * @return bool True if the spender is allowed, false otherwise.
+     */
+    function isSpenderAllowed(
+        address policyGuard,
+        address safe,
+        address token,
+        address spender
+    ) external view returns (bool) {
+        return $spenders[policyGuard][safe][token][spender];
     }
 }

--- a/contracts/policies/ERC20TransferPolicy.sol
+++ b/contracts/policies/ERC20TransferPolicy.sol
@@ -22,6 +22,9 @@ contract ERC20TransferPolicy is IPolicy {
         bool allowed;
     }
 
+    /**
+     * @dev Mapping of recipients for each Safe and token.
+     */
     // solhint-disable-next-line private-vars-leading-underscore
     mapping(address policyGuard => mapping(address safe => mapping(address token => mapping(address recipient => bool))))
         private $recipients;
@@ -92,5 +95,22 @@ contract ERC20TransferPolicy is IPolicy {
             $recipients[msg.sender][safe][target][recipientList[i].recipient] = recipientList[i].allowed;
         }
         return true;
+    }
+
+    /**
+     * @notice Check if a recipient is allowed for a specific Safe and token.
+     * @param policyGuard The policy guard address.
+     * @param safe The Safe address.
+     * @param token The token address.
+     * @param recipient The recipient address.
+     * @return bool Whether the recipient is allowed.
+     */
+    function isRecipientAllowed(
+        address policyGuard,
+        address safe,
+        address token,
+        address recipient
+    ) external view returns (bool) {
+        return $recipients[policyGuard][safe][token][recipient];
     }
 }

--- a/test/allowedModulePolicy.spec.ts
+++ b/test/allowedModulePolicy.spec.ts
@@ -1,0 +1,210 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai'
+import { ZeroAddress } from 'ethers'
+import { ethers } from 'hardhat'
+
+import { createConfiguration, createSafe, execTransaction, randomAddress, SafeOperation } from '../src/utils'
+import { deploySafePolicyGuard, deploySafeContracts, deployAllowedModulePolicy } from './deploy'
+
+describe('AllowedModulePolicy', function () {
+  async function fixture() {
+    const [, owner, other] = await ethers.getSigners()
+
+    // Deploy the SafePolicyGuard contract
+    const { safePolicyGuard } = await deploySafePolicyGuard()
+
+    // Deploy the Safe contracts
+    const { safeProxyFactory, safe: safeSingleton } = await deploySafeContracts()
+    const safe = await createSafe({
+      owner,
+      guard: ZeroAddress, // No guard at this point
+      saltNonce: BigInt(0x8),
+      safeProxyFactory,
+      singleton: safeSingleton
+    })
+
+    // Deploy AllowedModulePolicy contract
+    const { allowedModulePolicy } = await deployAllowedModulePolicy()
+
+    // Deploy TestModule contract
+    const TestModuleFactory = await ethers.getContractFactory('TestModule')
+    const testModule = await TestModuleFactory.deploy()
+
+    return {
+      owner,
+      other,
+      safePolicyGuard,
+      safe,
+      allowedModulePolicy,
+      testModule
+    }
+  }
+
+  describe('Unit tests', function () {
+    it('Should not allow a module that was not configured', async function () {
+      const { owner, safe, allowedModulePolicy, testModule } = await loadFixture(fixture)
+
+      const safeAddress = await safe.getAddress()
+      const moduleAddress = await testModule.getAddress()
+      const randomModuleAddress = randomAddress()
+
+      // Configure only one module
+      await allowedModulePolicy.connect(owner).configure(
+        safeAddress,
+        0, // AccessSelector doesn't matter for this policy
+        ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
+      )
+
+      // Check that the configured module is allowed
+      expect(await allowedModulePolicy.isModuleAllowed(owner, safeAddress, moduleAddress)).to.be.true
+
+      // Check that the random module is not allowed
+      expect(await allowedModulePolicy.isModuleAllowed(owner, safeAddress, randomModuleAddress)).to.be.false
+    })
+
+    it('Should return the magic value for allowed module in checkTransaction', async function () {
+      const { safe, allowedModulePolicy, testModule } = await loadFixture(fixture)
+
+      const safeAddress = await safe.getAddress()
+      const moduleAddress = await testModule.getAddress()
+
+      // Configure the module
+      await allowedModulePolicy.configure(
+        safeAddress,
+        0, // AccessSelector doesn't matter for this policy
+        ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
+      )
+
+      // Create context with module address
+      const context = ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
+
+      // Call checkTransaction and verify it returns the magic value
+      const result = await allowedModulePolicy.checkTransaction(
+        safeAddress,
+        randomAddress(), // to address (doesn't matter for this policy)
+        0, // value (doesn't matter for this policy)
+        '0x', // data (doesn't matter for this policy)
+        SafeOperation.Call,
+        context,
+        0 // AccessSelector.T (doesn't matter for this policy)
+      )
+
+      // This should match IPolicy.checkTransaction.selector
+      expect(result).to.equal('0x2c5dcbd7')
+    })
+
+    it('Should revert on checkTransaction for non-allowed module', async function () {
+      const { safe, allowedModulePolicy } = await loadFixture(fixture)
+
+      const safeAddress = await safe.getAddress()
+      const randomModuleAddress = randomAddress()
+
+      // Create context with a random non-configured module address
+      const context = ethers.AbiCoder.defaultAbiCoder().encode(['address'], [randomModuleAddress])
+
+      // Call checkTransaction and expect it to revert
+      await expect(
+        allowedModulePolicy.checkTransaction(safeAddress, randomAddress(), 0, '0x', SafeOperation.Call, context, 0)
+      ).to.be.revertedWithCustomError(allowedModulePolicy, 'UnauthorizedModule')
+    })
+  })
+
+  describe('Integration with SafePolicyGuard', function () {
+    it('Should allow transactions from configured modules', async function () {
+      const { owner, safe, safePolicyGuard, allowedModulePolicy, testModule } = await loadFixture(fixture)
+
+      const testModuleAddress = await testModule.getAddress()
+      const target = randomAddress()
+
+      // Enable the module on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('enableModule', [testModuleAddress])
+      })
+
+      const configurations = [
+        createConfiguration({
+          target: target,
+          policy: await allowedModulePolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [testModuleAddress])
+        })
+      ]
+
+      // Configure the policy with our test module directly
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Set the module as allowed for this safe in the policy
+      expect(
+        await allowedModulePolicy.isModuleAllowed(
+          await safePolicyGuard.getAddress(),
+          await safe.getAddress(),
+          testModuleAddress
+        )
+      ).to.be.true
+
+      // Enable the guard specifically for modules
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setModuleGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // The module transaction should succeed
+      await testModule.executeTx(await safe.getAddress(), target, 0, '0x', SafeOperation.Call)
+    })
+
+    it('Should block transactions from unauthorized modules', async function () {
+      const { owner, safe, safePolicyGuard, allowedModulePolicy } = await loadFixture(fixture)
+
+      const unauthorizedModule = await (await ethers.getContractFactory('TestModule')).deploy()
+      const unauthorizedModuleAddress = await unauthorizedModule.getAddress()
+      const testModuleAddress = randomAddress() // Different module address
+      const target = randomAddress()
+
+      // Enable the module on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('enableModule', [unauthorizedModuleAddress])
+      })
+
+      const configurations = [
+        createConfiguration({
+          target: target,
+          policy: await allowedModulePolicy.getAddress(),
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [testModuleAddress])
+        })
+      ]
+
+      // Set up the guard with the policy for test module
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Enable the guard for modules
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setModuleGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // The module is not in the allowed list, so it should be blocked
+      await expect(
+        unauthorizedModule.executeTx(await safe.getAddress(), target, 0, '0x', SafeOperation.Call)
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+    })
+  })
+})

--- a/test/policyEngine.spec.ts
+++ b/test/policyEngine.spec.ts
@@ -1,0 +1,187 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai'
+import { ZeroAddress } from 'ethers'
+import { ethers } from 'hardhat'
+
+import { createSafe, SafeOperation, execTransaction, randomAddress, randomSelector } from '../src/utils'
+import { deploySafeContracts, deploySafePolicyGuard, deployMockPolicy } from './deploy'
+
+describe('PolicyEngine Edge Cases', function () {
+  async function fixture() {
+    const [, owner] = await ethers.getSigners()
+
+    const { safePolicyGuard } = await deploySafePolicyGuard()
+    const { safeProxyFactory, safe: safeSingleton } = await deploySafeContracts()
+    const safe = await createSafe({
+      owner,
+      guard: ZeroAddress,
+      saltNonce: BigInt(0x9),
+      safeProxyFactory,
+      singleton: safeSingleton
+    })
+
+    const { mockPolicy } = await deployMockPolicy()
+
+    const TestAccessSelectorFactory = await ethers.getContractFactory('TestAccessSelector')
+    const accessSelector = await TestAccessSelectorFactory.deploy()
+
+    return { owner, safe, safePolicyGuard, mockPolicy, accessSelector }
+  }
+
+  describe('Selector Decoding Edge Cases', function () {
+    it('Should handle empty calldata correctly', async function () {
+      const { safePolicyGuard, safe, accessSelector } = await loadFixture(fixture)
+
+      // Test with empty data (should use zero selector and fallback to operation-only access)
+      const [_access, _policy] = await safePolicyGuard.getPolicy(
+        await safe.getAddress(),
+        ZeroAddress,
+        '0x',
+        SafeOperation.Call
+      )
+
+      // Should create fallback selector for CALL operation when no exact match
+      const expectedFallbackAccess = await accessSelector.createFallback(SafeOperation.Call)
+
+      expect(_access).to.equal(expectedFallbackAccess) // Should use fallback selector
+    })
+
+    it('Should revert with invalid selector length (1-3 bytes)', async function () {
+      const { safePolicyGuard, safe } = await loadFixture(fixture)
+
+      // Test with 1 byte data
+      await expect(
+        safePolicyGuard.getPolicy(await safe.getAddress(), ZeroAddress, '0x12', SafeOperation.Call)
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'InvalidSelector')
+
+      // Test with 2 bytes data
+      await expect(
+        safePolicyGuard.getPolicy(await safe.getAddress(), ZeroAddress, '0x1234', SafeOperation.Call)
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'InvalidSelector')
+
+      // Test with 3 bytes data
+      await expect(
+        safePolicyGuard.getPolicy(await safe.getAddress(), ZeroAddress, '0x123456', SafeOperation.Call)
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'InvalidSelector')
+    })
+
+    it('Should handle exactly 4 bytes of data correctly', async function () {
+      const { safePolicyGuard, safe } = await loadFixture(fixture)
+
+      const selector = '0x12345678'
+      const [_access, policy] = await safePolicyGuard.getPolicy(
+        await safe.getAddress(),
+        ZeroAddress,
+        selector,
+        SafeOperation.Call
+      )
+
+      expect(policy).to.equal(ZeroAddress) // No policy configured, should be zero
+    })
+  })
+
+  describe('Policy Configuration Edge Cases', function () {
+    it('Should handle empty configuration arrays', async function () {
+      const { safePolicyGuard } = await loadFixture(fixture)
+
+      // Should not revert with empty configuration
+      await expect(safePolicyGuard.configureImmediately([])).to.not.be.reverted
+    })
+
+    it('Should handle policy overwrite correctly', async function () {
+      const { owner, safe, safePolicyGuard, mockPolicy } = await loadFixture(fixture)
+
+      const target = ZeroAddress
+      const selector = randomSelector()
+      const operation = SafeOperation.Call
+
+      // Deploy a second mock policy
+      const MockPolicyFactory = await ethers.getContractFactory('MockPolicy')
+      const secondMockPolicy = await MockPolicyFactory.deploy()
+
+      // Configure first policy through Safe transaction
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [
+            {
+              target,
+              selector,
+              operation,
+              policy: await mockPolicy.getAddress(),
+              data: '0x'
+            }
+          ]
+        ])
+      })
+
+      // Verify first policy is set
+      const [, firstPolicy] = await safePolicyGuard.getPolicy(await safe.getAddress(), target, selector, operation)
+      expect(firstPolicy).to.equal(await mockPolicy.getAddress())
+
+      // Configure second policy for same access selector (should overwrite)
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [
+            {
+              target,
+              selector,
+              operation,
+              policy: await secondMockPolicy.getAddress(),
+              data: '0x'
+            }
+          ]
+        ])
+      })
+
+      const [_retrievedAccess, retrievedPolicy] = await safePolicyGuard.getPolicy(
+        await safe.getAddress(),
+        target,
+        selector,
+        operation
+      )
+
+      // The policy should be the second one now (overwritten)
+      expect(retrievedPolicy).to.equal(await secondMockPolicy.getAddress())
+    })
+  })
+
+  describe('AccessSelector Library Edge Cases', function () {
+    it('Should correctly pack and unpack access selectors', async function () {
+      const TestAccessSelectorFactory = await ethers.getContractFactory('TestAccessSelector')
+      const accessSelector = await TestAccessSelectorFactory.deploy()
+
+      const target = randomAddress()
+      const selector = randomSelector()
+      const operation = SafeOperation.DelegateCall
+
+      const packed = await accessSelector.create(target, selector, operation)
+
+      // Verify unpacking
+      expect(await accessSelector.getTarget(packed)).to.equal(target)
+      expect(await accessSelector.getSelector(packed)).to.equal(selector)
+      expect(await accessSelector.getOperation(packed)).to.equal(operation)
+    })
+
+    it('Should create correct fallback selectors', async function () {
+      const { accessSelector } = await loadFixture(fixture)
+
+      const callFallback = await accessSelector.createFallback(SafeOperation.Call)
+      const delegateCallFallback = await accessSelector.createFallback(SafeOperation.DelegateCall)
+
+      // Fallback selectors should have zero address and selector
+      expect(await accessSelector.getTarget(callFallback)).to.equal(ZeroAddress)
+      expect(await accessSelector.getSelector(callFallback)).to.equal('0x00000000')
+      expect(await accessSelector.getOperation(callFallback)).to.equal(SafeOperation.Call)
+
+      expect(await accessSelector.getTarget(delegateCallFallback)).to.equal(ZeroAddress)
+      expect(await accessSelector.getSelector(delegateCallFallback)).to.equal('0x00000000')
+      expect(await accessSelector.getOperation(delegateCallFallback)).to.equal(SafeOperation.DelegateCall)
+    })
+  })
+})


### PR DESCRIPTION
## TLDR
- Updated the contract to have view functions for reading private storage.
- Added more tests for higher coverage of all possible code paths.
- Updated the storage of contracts to be `private` to keep consistency.

## LLM Description
This pull request introduces several improvements and refactorings to the policy engine contracts and their associated tests. The main themes are: enhanced encapsulation of internal mappings, addition of public view functions for policy state inspection, improved error handling, and expanded test coverage for policy edge cases.

**Smart contract improvements and refactoring:**

* Internal mappings in `AllowedModulePolicy`, `CoSignerPolicy`, `ERC20ApprovePolicy`, and `ERC20TransferPolicy` are now private, using the ` prefix for clarity and encapsulation. Public view functions (`isModuleAllowed`, `getCoSigner`, `isSpenderAllowed`, `isRecipientAllowed`) have been added to allow external inspection of policy state without exposing the mappings directly. [[1]](diffhunk://#diff-fe87765f9b30bc26c075bf4e826057bc7dfffd86b0639f4a96e56fe22d135027L14-R16) [[2]](diffhunk://#diff-fe87765f9b30bc26c075bf4e826057bc7dfffd86b0639f4a96e56fe22d135027L60-R69) [[3]](diffhunk://#diff-a0b084b6c0208030911b624e1924216f38bdad5db0572328c1196518e1141dddR14-R23) [[4]](diffhunk://#diff-a0b084b6c0208030911b624e1924216f38bdad5db0572328c1196518e1141dddL59-R77) [[5]](diffhunk://#diff-3b326ea661d61309fed63bb199ad6380d0c579b4c7d5516b5d011d72e8492802R25-R27) [[6]](diffhunk://#diff-3b326ea661d61309fed63bb199ad6380d0c579b4c7d5516b5d011d72e8492802R95-R111) [[7]](diffhunk://#diff-22325b21959761caad1a5ec945f6b94e12054e9ba67bbe02dfbddccd1fd38283R25-R27) [[8]](diffhunk://#diff-22325b21959761caad1a5ec945f6b94e12054e9ba67bbe02dfbddccd1fd38283R99-R115)

* The `PolicyEngine` contract's `confirmPolicy` method now configures the policy before updating the mapping, ensuring atomicity and correctness in policy application.

* Improved error handling in `CoSignerPolicy` by adding a specific revert for the case where no cosigner is configured.

**Testing and documentation:**

* Added a comprehensive test suite for `AllowedModulePolicy`, including both unit and integration tests with `SafePolicyGuard`, covering allowed and unauthorized modules.

* Expanded the `ERC20TransferPolicy` test suite to cover edge cases such as empty recipient list configuration and toggling recipient permissions.

* Updated the `README.md` with clear instructions for testing, gas benchmarking, and deployment, as well as a note on configuring delay parameters.

**Test improvements:**

* Refactored test fixtures to include all relevant signers and deployed contracts, and added an `accessSelector` for more robust policy configuration in tests. [[1]](diffhunk://#diff-4d550ab6f80206c8631c9ce458e67cbcb82d6a0c066867420bcd786888a8d685L11-R11) [[2]](diffhunk://#diff-4d550ab6f80206c8631c9ce458e67cbcb82d6a0c066867420bcd786888a8d685R35-R48)

These changes collectively improve code maintainability, test coverage, and usability for developers and auditors.