### PR TITLE
Following CEI Pattern

### DIFF
--- a/contracts/core/PolicyEngine.sol
+++ b/contracts/core/PolicyEngine.sol
@@ -155,11 +155,11 @@ abstract contract PolicyEngine is IPolicyEngine {
         // Creating access selector for a policy
         AccessSelector.T access = AccessSelector.create(target, selector, operation);
 
-        // Configuring policy
-        require(IPolicy(policy).configure(safe, access, data), PolicyConfigurationFailed());
-
         // Update the policy mapping
         $policies[safe][access] = policy;
+
+        // Configuring policy
+        require(IPolicy(policy).configure(safe, access, data), PolicyConfigurationFailed());
 
         emit PolicyConfirmed(safe, target, selector, operation, policy, data);
     }


### PR DESCRIPTION
## TLDR
Following the CEI (Check Effect Interaction) pattern while confirming the policy to avoid reentrancy issues.

## LLM Description
This pull request makes a minor change to the order of operations in the `PolicyEngine` contract. The update ensures that the policy mapping is updated before the policy is configured, which can help maintain consistency if the configuration process relies on the mapping.

- **Order of Operations Update:**
  - In `PolicyEngine.sol`, the `$policies[safe][access]` mapping is now updated before calling `IPolicy(policy).configure`, instead of after.