### PR TITLE
App contract changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ ETHERSCAN_API_KEY=
 
 # Required for gas report.
 HARDHAT_GAS_REPORTER_ENABLED=true
+
+# Required for deployment (whether for Safe App [true] or production [false])
+DEMO=false

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ tsconfig.tsbuildinfo
 
 # Cursor
 .cursor/
+
+# Excalidraw
+*.excalidraw

--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -220,7 +220,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
      *      This is a convenience function to avoid having to call `configurePolicy` and then
      *      `confirmPolicy` separately with a delay.
      */
-    function configureImmediately(Configuration[] calldata configurations) external {
+    function configureImmediately(Configuration[] calldata configurations) external virtual {
         for (uint256 i = 0; i < configurations.length; i++) {
             _confirmPolicy(
                 msg.sender,
@@ -238,7 +238,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
      * @param configureRoot The root of the configuration to be applied.
      * @dev This can be used to set multiple policies at once.
      */
-    function requestConfiguration(bytes32 configureRoot) external {
+    function requestConfiguration(bytes32 configureRoot) external virtual {
         require(rootConfigured[msg.sender][configureRoot] == 0, RootAlreadyConfigured(configureRoot));
         rootConfigured[msg.sender][configureRoot] = block.timestamp + DELAY;
         emit RootConfigured(msg.sender, configureRoot, block.timestamp + DELAY);
@@ -251,7 +251,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
      *      This is not behind a delay, as only pending configurations can be invalidated, and
      *      this allows invalidating unintended policies immediately before it is confirmed.
      */
-    function invalidateRoot(bytes32 configureRoot) external {
+    function invalidateRoot(bytes32 configureRoot) external virtual {
         require(rootConfigured[msg.sender][configureRoot] != 0, RootNotConfigured(configureRoot));
         delete rootConfigured[msg.sender][configureRoot];
         emit RootInvalidated(msg.sender, configureRoot);
@@ -262,7 +262,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
      * @param configurations The array of configurations to be applied.
      * @dev This can be used to set multiple policies at once.
      */
-    function applyConfiguration(Configuration[] calldata configurations) external {
+    function applyConfiguration(Configuration[] calldata configurations) external virtual {
         bytes32 configureRoot = keccak256(abi.encode(configurations));
         require(rootConfigured[msg.sender][configureRoot] != 0, RootNotConfigured(configureRoot));
         require(block.timestamp >= rootConfigured[msg.sender][configureRoot], RootConfigurationPending());

--- a/contracts/test/App/AppSafePolicyGuard.sol
+++ b/contracts/test/App/AppSafePolicyGuard.sol
@@ -30,8 +30,7 @@ contract AppSafePolicyGuard is SafePolicyGuard {
     /**
      * @param delay The delay for the configuration change.
      */
-    constructor(uint256 delay) SafePolicyGuard(delay) {
-    }
+    constructor(uint256 delay) SafePolicyGuard(delay) {}
 
     /**
      * @notice Configures and confirms multiple policies for an address.
@@ -43,11 +42,11 @@ contract AppSafePolicyGuard is SafePolicyGuard {
      */
     function configureImmediately(Configuration[] calldata configurations) external override {
         bytes32 configureRoot = keccak256(abi.encode(configurations));
-        
+
         // Store the configurations for this root
         _configureRoots[msg.sender].add(configureRoot);
         _configurations[configureRoot] = configurations;
-        
+
         // Apply the policies immediately
         for (uint256 i = 0; i < configurations.length; i++) {
             _confirmPolicy(

--- a/contracts/test/App/AppSafePolicyGuard.sol
+++ b/contracts/test/App/AppSafePolicyGuard.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity =0.8.28;
+
+import {SafePolicyGuard, AccessSelector} from "../../SafePolicyGuard.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+/**
+ * @title App Safe Policy Guard
+ * @dev Used for Safe App demo purposes.
+ */
+contract AppSafePolicyGuard is SafePolicyGuard {
+    using AccessSelector for AccessSelector.T;
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
+    /**
+     * @notice Configuration roots which are either pending or confirmed.
+     */
+    mapping(address => EnumerableSet.Bytes32Set) private _configureRoots;
+
+    /**
+     * @notice Configuration mapping for each root.
+     */
+    mapping(bytes32 => Configuration[]) private _configurations;
+
+    /**
+     * @notice Thrown when a root is not configured yet.
+     */
+    error RootNotConfiguredYet(bytes32 configureRoot);
+
+    /**
+     * @param delay The delay for the configuration change.
+     */
+    constructor(uint256 delay) SafePolicyGuard(delay) {
+    }
+
+    /**
+     * @notice Configures and confirms multiple policies for an address.
+     * @param configurations The array of configurations to be applied.
+     * @dev This does not have to check if the guard is enabled, as if the guard is set,
+     *      then this tx will fail in `checkTransaction`.
+     *      This is a convenience function to avoid having to call `configurePolicy` and then
+     *      `confirmPolicy` separately with a delay.
+     */
+    function configureImmediately(Configuration[] calldata configurations) external override {
+        bytes32 configureRoot = keccak256(abi.encode(configurations));
+        
+        // Store the configurations for this root
+        _configureRoots[msg.sender].add(configureRoot);
+        _configurations[configureRoot] = configurations;
+        
+        // Apply the policies immediately
+        for (uint256 i = 0; i < configurations.length; i++) {
+            _confirmPolicy(
+                msg.sender,
+                configurations[i].target,
+                configurations[i].selector,
+                configurations[i].operation,
+                configurations[i].policy,
+                configurations[i].data
+            );
+        }
+    }
+
+    /**
+     * @notice Requests a policy configuration change.
+     * @param configureRoot The root of the configuration to be applied.
+     * @dev This can be used to set multiple policies at once.
+     */
+    function requestConfiguration(bytes32 configureRoot) external override {
+        require(rootConfigured[msg.sender][configureRoot] == 0, RootAlreadyConfigured(configureRoot));
+        rootConfigured[msg.sender][configureRoot] = block.timestamp + DELAY;
+        emit RootConfigured(msg.sender, configureRoot, block.timestamp + DELAY);
+    }
+
+    /**
+     * @notice Compliments a previously requested policy configuration change.
+     * @param configurations The array of configurations to be applied.
+     * @dev This function allows adding the configuration details to the root for the safe app.
+     */
+    function complimentRequestConfiguration(Configuration[] calldata configurations) external {
+        bytes32 configureRoot = keccak256(abi.encode(configurations));
+        require(rootConfigured[msg.sender][configureRoot] != 0, RootNotConfiguredYet(configureRoot));
+        _configureRoots[msg.sender].add(configureRoot);
+        _configurations[configureRoot] = configurations;
+    }
+
+    /**
+     * @notice Invalidates a policy configuration change.
+     * @param configureRoot The root of the configuration to be invalidated.
+     * @dev Invalidation can only be done if the configuration is pending.
+     *      This is not behind a delay, as only pending configurations can be invalidated, and
+     *      this allows invalidating unintended policies immediately before it is confirmed.
+     */
+    function invalidateRoot(bytes32 configureRoot) external override {
+        require(rootConfigured[msg.sender][configureRoot] != 0, RootNotConfigured(configureRoot));
+        delete rootConfigured[msg.sender][configureRoot];
+        _configureRoots[msg.sender].remove(configureRoot);
+        emit RootInvalidated(msg.sender, configureRoot);
+    }
+
+    /**
+     * @notice Applies a policy configuration change.
+     * @param configurations The array of configurations to be applied.
+     * @dev This can be used to set multiple policies at once.
+     */
+    function applyConfiguration(Configuration[] calldata configurations) external override {
+        bytes32 configureRoot = keccak256(abi.encode(configurations));
+        require(rootConfigured[msg.sender][configureRoot] != 0, RootNotConfigured(configureRoot));
+        require(block.timestamp >= rootConfigured[msg.sender][configureRoot], RootConfigurationPending());
+        delete rootConfigured[msg.sender][configureRoot];
+        for (uint256 i = 0; i < configurations.length; i++) {
+            _confirmPolicy(
+                msg.sender,
+                configurations[i].target,
+                configurations[i].selector,
+                configurations[i].operation,
+                configurations[i].policy,
+                configurations[i].data
+            );
+        }
+    }
+
+    /**
+     * @notice Gets the configurations for a given configuration root.
+     * @param configureRoot The root hash of the configurations.
+     * @return The array of configurations.
+     */
+    function getConfigurations(bytes32 configureRoot) external view returns (Configuration[] memory) {
+        return _configurations[configureRoot];
+    }
+
+    /**
+     * @notice Gets all configuration roots for a safe address.
+     * @param safe The safe address.
+     * @return The array of configuration root hashes.
+     */
+    function getConfigurationRoots(address safe) external view returns (bytes32[] memory) {
+        return _configureRoots[safe].values();
+    }
+}

--- a/contracts/test/App/AppSafePolicyGuard.sol
+++ b/contracts/test/App/AppSafePolicyGuard.sol
@@ -76,7 +76,7 @@ contract AppSafePolicyGuard is SafePolicyGuard {
      * @param configurations The array of configurations to be applied.
      * @dev This function allows adding the configuration details to the root for the safe app.
      */
-    function complimentRequestConfiguration(Configuration[] calldata configurations) external {
+    function complementRequestConfiguration(Configuration[] calldata configurations) external {
         bytes32 configureRoot = keccak256(abi.encode(configurations));
         require(rootConfigured[msg.sender][configureRoot] != 0, RootNotConfiguredYet(configureRoot));
         _configureRoots[msg.sender].add(configureRoot);

--- a/deploy/deploy_contracts.ts
+++ b/deploy/deploy_contracts.ts
@@ -2,6 +2,7 @@ import { DeployFunction } from 'hardhat-deploy/types'
 import { promises as fs } from 'node:fs'
 
 const POLICIES_CONFIG_DELAY = process.env.POLICIES_CONFIG_DELAY ? parseInt(process.env.POLICIES_CONFIG_DELAY) : 0n
+const DEMO = process.env.DEMO ? process.env.DEMO === 'true' : false
 
 type Networks = Record<string, Record<string, string>>
 
@@ -34,13 +35,18 @@ const deploy: DeployFunction = async function ({ getChainId, getNamedAccounts, d
   }
 
   // Guard
-  await deployContract('SafePolicyGuard', [POLICIES_CONFIG_DELAY])
+  if (DEMO) {
+    await deployContract('AppSafePolicyGuard', [POLICIES_CONFIG_DELAY])
+  } else {
+    await deployContract('SafePolicyGuard', [POLICIES_CONFIG_DELAY])
+  }
 
   // Policies
   await deployContract('AllowPolicy')
+  await deployContract('AllowedModulePolicy')
   await deployContract('CoSignerPolicy')
-  await deployContract('ERC20TransferPolicy')
   await deployContract('ERC20ApprovePolicy')
+  await deployContract('ERC20TransferPolicy')
   await deployContract('MultiSendPolicy')
   await deployContract('NativeTransferPolicy')
 


### PR DESCRIPTION
## TLDR
- Added an App compatible version of the Safe Policy Guard, which makes it easier to fetch data about the guard.
- Added the same into the deployment script.
- Uses the `DEMO` env variable to know which contract to deploy. By default, it is set to false (`env.sample`), which can be used to deploy the app version of the Safe Policy Guard.

## LLM Description
This pull request introduces support for a Safe App demo mode and refactors the deployment and contract logic to accommodate it. The key changes include adding a new `AppSafePolicyGuard` contract specifically for demo purposes, updating deployment scripts to conditionally deploy the appropriate contract based on an environment variable, and making contract functions overrideable for extensibility.

**Safe App Demo Support**

* Added the `DEMO` environment variable to `.env.example` to control demo mode deployment.
* Introduced the new `AppSafePolicyGuard` contract, which extends `SafePolicyGuard` with additional demo-specific features such as configuration root tracking and helper view functions.

**Deployment Logic Updates**

* Updated `deploy/deploy_contracts.ts` to check the `DEMO` environment variable and deploy either `AppSafePolicyGuard` or `SafePolicyGuard` accordingly. Also adjusted the order and inclusion of policy contract deployments. [[1]](diffhunk://#diff-3a338933ef892a5b4b73682af210c12bf81bf78bba458379759122224e51a7c4R5) [[2]](diffhunk://#diff-3a338933ef892a5b4b73682af210c12bf81bf78bba458379759122224e51a7c4R38-R49)

**Contract Extensibility**

* Marked key functions (`configureImmediately`, `requestConfiguration`, `invalidateRoot`, `applyConfiguration`) in `SafePolicyGuard` as `virtual` to allow overriding in derived contracts like `AppSafePolicyGuard`. [[1]](diffhunk://#diff-eb79142b3e8c4c9e9f789b0da92aa657ad12ba14b016b012e25cc95f7e23458eL223-R223) [[2]](diffhunk://#diff-eb79142b3e8c4c9e9f789b0da92aa657ad12ba14b016b012e25cc95f7e23458eL241-R241) [[3]](diffhunk://#diff-eb79142b3e8c4c9e9f789b0da92aa657ad12ba14b016b012e25cc95f7e23458eL254-R254) [[4]](diffhunk://#diff-eb79142b3e8c4c9e9f789b0da92aa657ad12ba14b016b012e25cc95f7e23458eL265-R265)