### PR TITLE
Deny Policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @safe-research/all
+* @safe-research/dev

--- a/app/src/utils/helper.ts
+++ b/app/src/utils/helper.ts
@@ -152,7 +152,6 @@ export const call = async (
   method: string,
   params: unknown[],
   returnArray: boolean = false
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> => {
   const resp = await sdk.eth.call([
     {

--- a/contracts/policies/DenyPolicy.sol
+++ b/contracts/policies/DenyPolicy.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity =0.8.28;
+
+import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
+import {AccessSelector} from "../libraries/AccessSelector.sol";
+
+/**
+ * @title Deny Policy
+ * @dev Denies a transaction.
+ */
+contract DenyPolicy is IPolicy {
+    /**
+     * @inheritdoc IPolicy
+     * @dev This policy always returns zero selector for a particular access selector.
+     *      This is to deny a certain transaction always.
+     */
+    function checkTransaction(
+        address,
+        address,
+        uint256,
+        bytes calldata,
+        Operation,
+        bytes calldata,
+        AccessSelector.T
+    ) external pure override returns (bytes4 magicValue) {}
+
+    /**
+     * @inheritdoc IPolicy
+     * @dev This policy does not require any configuration.
+     */
+    function configure(address, AccessSelector.T, bytes memory) external pure override returns (bool) {
+        return true;
+    }
+}

--- a/contracts/policies/DenyPolicy.sol
+++ b/contracts/policies/DenyPolicy.sol
@@ -14,6 +14,7 @@ contract DenyPolicy is IPolicy {
      * @dev This policy always returns zero selector for a particular access selector.
      *      This is to deny a certain transaction always.
      */
+    // solhint-disable no-empty-blocks
     function checkTransaction(
         address,
         address,
@@ -23,6 +24,7 @@ contract DenyPolicy is IPolicy {
         bytes calldata,
         AccessSelector.T
     ) external pure override returns (bytes4 magicValue) {}
+    // solhint-enable no-empty-blocks
 
     /**
      * @inheritdoc IPolicy

--- a/deploy/deploy_contracts.ts
+++ b/deploy/deploy_contracts.ts
@@ -58,6 +58,7 @@ const deploy: DeployFunction = async function ({ run, getChainId, getNamedAccoun
 
   // Policies
   await deployContract('AllowPolicy')
+  await deployContract('DenyPolicy')
   await deployContract('AllowedModulePolicy')
   await deployContract('CoSignerPolicy')
   await deployContract('ERC20ApprovePolicy')

--- a/test/denyPolicy.spec.ts
+++ b/test/denyPolicy.spec.ts
@@ -1,0 +1,93 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai'
+import { ZeroAddress } from 'ethers'
+import { ethers } from 'hardhat'
+
+import { createConfiguration, createSafe, execTransaction, randomAddress } from '../src/utils'
+import { deploySafePolicyGuard, deploySafeContracts, deployAllowPolicy, deployDenyPolicy } from './deploy'
+
+describe('DenyPolicy', function () {
+  async function fixture() {
+    const [, owner, other] = await ethers.getSigners()
+
+    // Deploy the SafePolicyGuard contract
+    const { safePolicyGuard } = await deploySafePolicyGuard()
+
+    // Deploy the Safe contracts
+    const { safeProxyFactory, safe: safeSingleton } = await deploySafeContracts()
+    const safe = await createSafe({
+      owner,
+      guard: ZeroAddress, // No guard at this point
+      saltNonce: BigInt(0xa),
+      safeProxyFactory,
+      singleton: safeSingleton
+    })
+
+    // Deploy AllowPolicy contract
+    const { allowPolicy } = await deployAllowPolicy()
+    const { denyPolicy } = await deployDenyPolicy()
+
+    // Deploy Test Access Selector
+    const AccessSelectorFactory = await ethers.getContractFactory('TestAccessSelector')
+    const accessSelector = await AccessSelectorFactory.deploy()
+
+    // Configure the AllowPolicy as a fallback to allow any transactions
+    const configurations = [createConfiguration({ policy: await allowPolicy.getAddress() })]
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: await safePolicyGuard.getAddress(),
+      data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+    })
+
+    return { owner, other, safePolicyGuard, safe, denyPolicy, accessSelector }
+  }
+
+  describe('Integration with SafePolicyGuard', function () {
+    it('Should deny particular transaction when configured through deny policy', async function () {
+      const { owner, safePolicyGuard, safe, denyPolicy } = await loadFixture(fixture)
+
+      const target = randomAddress()
+      const value = ethers.parseEther('1')
+
+      const configurations = [createConfiguration({ target, policy: await denyPolicy.getAddress() })]
+
+      // Configure the deny policy to send some value to the target
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+      })
+
+      // Enable the guard on safe
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      // Send some ETH from owner to the safe for next transaction
+      await owner.sendTransaction({
+        to: await safe.getAddress(),
+        value
+      })
+
+      // Try to execute the particular transaction
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: target,
+          value
+        })
+      )
+        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+        .withArgs(denyPolicy)
+
+      // Verify the transaction was not executed by checking the target's balance
+      expect(await ethers.provider.getBalance(target)).to.equal(0n)
+    })
+  })
+})

--- a/test/deploy/DenyPolicy.ts
+++ b/test/deploy/DenyPolicy.ts
@@ -1,0 +1,21 @@
+import { ContractRunner } from 'ethers'
+import { ethers } from 'hardhat'
+
+import { DenyPolicy } from '../../typechain-types'
+import { deterministicDeployment } from './util/create2'
+
+export type DeployOptions =
+  | {
+      runner?: ContractRunner
+    }
+  | undefined
+
+export async function deploy({ runner }: DeployOptions = {}) {
+  const denyPolicyFactory = await ethers.getContractFactory('DenyPolicy')
+  const factory = runner ? denyPolicyFactory.connect(runner) : denyPolicyFactory
+  const denyPolicy = (await deterministicDeployment(factory, [])) as unknown as DenyPolicy
+
+  return {
+    denyPolicy
+  }
+}

--- a/test/deploy/index.ts
+++ b/test/deploy/index.ts
@@ -1,6 +1,7 @@
 export { deploy as deploySafeContracts } from './SafeContracts'
 export { deploy as deploySafePolicyGuard } from './SafePolicyGuard'
 export { deploy as deployAllowPolicy } from './AllowPolicy'
+export { deploy as deployDenyPolicy } from './DenyPolicy'
 export { deploy as deployAllowedModulePolicy } from './AllowedModulePolicy'
 export { deploy as deployERC20ApprovePolicy } from './ERC20ApprovePolicy'
 export { deploy as deployERC20TransferPolicy } from './ERC20TransferPolicy'


### PR DESCRIPTION
## TLDR
Added a deny policy in the case where we want to set up a Safe which allows every transaction (`AllowPolicy` as fallback), and only wants to stop execution of certain transactions whose metadata (target, selector and operation) is known already.

Added the corresponding tests and deployment script.

## LLM Description
This pull request introduces a new `DenyPolicy` smart contract, integrates its deployment into the system, and adds comprehensive tests to verify its functionality. The main goal is to enable the Safe system to explicitly deny certain transactions based on policy configuration. The changes are grouped into contract implementation, deployment integration, and testing enhancements.

**Contract Implementation:**

* Added the new `DenyPolicy` smart contract in `contracts/policies/DenyPolicy.sol`, which implements the `IPolicy` interface and always denies configured transactions.

**Deployment Integration:**

* Updated deployment scripts (`deploy/deploy_contracts.ts`) to deploy the new `DenyPolicy` contract alongside other policies.
* Added a deployment utility for `DenyPolicy` in `test/deploy/DenyPolicy.ts` and exported it via `test/deploy/index.ts` for use in tests. [[1]](diffhunk://#diff-910f5a645bf9a92e443329f53b814281a677c4b89f3b8ef9968e0555abebff67R1-R21) [[2]](diffhunk://#diff-2e8c2bc24d2a0b822af851a46dec64b5740f1b49b2a0f2d603475c4c5dd67eb8R4)

**Testing Enhancements:**

* Added a new test suite `test/denyPolicy.spec.ts` that verifies `DenyPolicy` correctly denies transactions when configured, ensuring the Safe system reverts unauthorized actions and maintains target balances.

**Project Ownership Update:**

* Changed the default code ownership in `.github/CODEOWNERS` from `@safe-research/all` to `@safe-research/dev`.