### PR TITLE
Allowed Calls Update

### DIFF
--- a/app/src/utils/helper.ts
+++ b/app/src/utils/helper.ts
@@ -152,7 +152,6 @@ export const call = async (
   method: string,
   params: unknown[],
   returnArray: boolean = false
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> => {
   const resp = await sdk.eth.call([
     {

--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -111,7 +111,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         uint256 value,
         bytes calldata data,
         Operation operation
-    ) internal view virtual returns (bool) {
+    ) internal view virtual override returns (bool) {
         bytes4 selector = _decodeSelector(data);
 
         // Invalidate Root
@@ -150,10 +150,6 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         // transaction that is rarely used, and therefore should not be covered by the access
         // control system.
         require(gasPrice == 0, NonZeroGasPrice());
-
-        if (_allowedCalls(to, value, data, operation)) {
-            return;
-        }
 
         checkTransaction(msg.sender, to, value, data, operation, _decodeContext(signatures));
     }

--- a/contracts/test/App/AppSafePolicyGuard.sol
+++ b/contracts/test/App/AppSafePolicyGuard.sol
@@ -76,24 +76,6 @@ contract AppSafePolicyGuard is SafePolicyGuard {
     }
 
     /**
-     * @inheritdoc IPolicyEngine
-     * @dev This is overridden to handle `MultiSend` transactions.
-     */
-    function checkTransaction(
-        address safe,
-        address to,
-        uint256 value,
-        bytes calldata data,
-        Operation operation,
-        bytes memory context
-    ) public view override returns (address) {
-        if (_allowedCalls(to, value, data, operation)) {
-            return address(0);
-        }
-        return super.checkTransaction(safe, to, value, data, operation, context);
-    }
-
-    /**
      * @notice Requests a policy configuration change.
      * @param configureRoot The root of the configuration to be applied.
      * @dev This can be used to set multiple policies at once.


### PR DESCRIPTION
## TLDR
Using `_allowedCalls`, we allowed the transactions that are executed to change things in the guard (example: requesting, applying configurations, etc). However, due to its initial development, we didn't consider the possibility of using MultiSend for guard configuration. Technically, we could batch configuration changes within a single configuration root, but to consider the integrity of the transaction flow, we decided to only keep a single path. Thus, we added the `_allowedCalls` within the policy engine itself, and overrode its functionality within the Safe Policy Guard to extend what is allowed, thus keeping consistency on how the transactions flow.

Also, I added an additional test to verify the same.

P.S. Refactored some old tests as well.

## LLM Description
This pull request refactors the Safe policy engine and related tests to improve modularity, extensibility, and test coverage. The main changes include introducing an overridable `_allowedCalls` hook in the policy engine, simplifying transaction checks, and enhancing test utilities and cases for policy configuration and multi-send scenarios.

### Smart contract architecture and extensibility

* Added the `_allowedCalls` virtual hook in `PolicyEngine` (`PolicyEngine.sol`) to allow inherited contracts to bypass policy checks for certain calls, improving flexibility for future extensions.
* Updated `SafePolicyGuard` to override `_allowedCalls` and removed redundant transaction checks, streamlining the logic for handling allowed calls. [[1]](diffhunk://#diff-eb79142b3e8c4c9e9f789b0da92aa657ad12ba14b016b012e25cc95f7e23458eL114-R114) [[2]](diffhunk://#diff-eb79142b3e8c4c9e9f789b0da92aa657ad12ba14b016b012e25cc95f7e23458eL154-L157)
* Removed the redundant override of `checkTransaction` in `AppSafePolicyGuard` since the new hook covers its use case.
* Modified the main transaction check flow to use `_allowedCalls` before enforcing policy, ensuring calls allowed by the hook are not subject to policy restrictions.

### Test improvements and utilities

* Refactored test utilities to use the new `createConfiguration` and `getConfigurationRoot` helpers, simplifying configuration setup in tests. [[1]](diffhunk://#diff-309763947c9e0ba17d2c96c424680b45475efa6ba8086859116e5c9679434798L17-R18) [[2]](diffhunk://#diff-f9a3bfb3e01aa7e02a823a36c04e53fa8aeab6ff25a1d4d89c5ece13c919e3e3L6-R13)
* Added a new test case for multi-send transactions that verifies configuration of multiple policies in a single batch, improving coverage for complex scenarios.
* Updated edge case tests to use the refactored configuration helpers and clarified policy overwrite and clearing logic. [[1]](diffhunk://#diff-f9a3bfb3e01aa7e02a823a36c04e53fa8aeab6ff25a1d4d89c5ece13c919e3e3R109-R136) [[2]](diffhunk://#diff-f9a3bfb3e01aa7e02a823a36c04e53fa8aeab6ff25a1d4d89c5ece13c919e3e3R152-R177)

These changes make the policy engine more modular and easier to maintain, while the improved tests ensure correctness for policy configuration and multi-send operations.