### PR TITLE
App Publishing

### DIFF
--- a/.github/workflows/app_publish.yml
+++ b/.github/workflows/app_publish.yml
@@ -1,0 +1,59 @@
+name: Policy Engine Safe App to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: "app/package-lock.json"
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Install dependencies
+        working-directory: app
+        run: npm ci
+      - name: Build
+        working-directory: app
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: app/dist
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build and deployment of the Policy Engine Safe App to GitHub Pages. The workflow is triggered on pushes to the `main` branch and can also be run manually. It sets up permissions, manages concurrency for deployments, and defines separate jobs for building and deploying the app.

**Automation and deployment:**

* Added `.github/workflows/app_publish.yml` to automate building and deploying the app to GitHub Pages, including steps for Node setup, dependency installation, build, artifact upload, and deployment.
* Configured workflow triggers for both pushes to `main` and manual dispatch via the Actions tab.
* Set permissions for the `GITHUB_TOKEN` to allow content read, pages write, and id-token write, ensuring secure deployment.
* Implemented concurrency controls to prevent overlapping deployments while allowing production jobs to complete.
* Defined build and deploy jobs, with deployment to the `github-pages` environment and automatic publication of the built app.