### PR TITLE
Deny App Integration

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -877,7 +877,6 @@ function App() {
                     label="Policy"
                     required
                   >
-                    {/* Write a for loop going through POLICY_ADDRESS_NAME */}
                     {POLICY_ADDRESS_NAME.map(policy => (
                       <option key={policy.address} value={policy.address}>
                         {policy.name}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -18,16 +18,13 @@ import {
 } from '@mui/material'
 import {
   ALLOW_POLICY_ADDRESS,
-  ALLOWED_MODULE_POLICY_ADDRESS,
   CONTRACT_INTERFACE,
   COSIGNER_POLICY_ADDRESS,
-  ERC20_APPROVE_POLICY_ADDRESS,
-  ERC20_TRANSFER_POLICY_ADDRESS,
   GUARD_STORAGE_SLOT,
   MILLISECONDS_IN_SECOND,
   MULTISEND_CALL_ONLY,
   MULTISEND_POLICY_ADDRESS,
-  NATIVE_TRANSFER_POLICY_ADDRESS,
+  POLICY_ADDRESS_NAME,
   ZERO_SELECTOR,
 } from './utils/constants'
 import type { FormData, AccessInfo, PendingInfo } from './utils/types'
@@ -494,7 +491,7 @@ function App() {
       const data = encodeData(formData.policy, formData.data)
 
       // Set default selector if empty (For fallback)
-      const selector = formData.selector || '0x00000000'
+      const selector = formData.selector || ZERO_SELECTOR
 
       const configurations: FormData[] = [
         {
@@ -880,25 +877,12 @@ function App() {
                     label="Policy"
                     required
                   >
-                    <option value={ALLOW_POLICY_ADDRESS}>Allow Policy</option>
-                    <option value={ALLOWED_MODULE_POLICY_ADDRESS}>
-                      Allow Module Policy
-                    </option>
-                    <option value={COSIGNER_POLICY_ADDRESS}>
-                      Cosigner Policy
-                    </option>
-                    <option value={ERC20_APPROVE_POLICY_ADDRESS}>
-                      ERC20 Approve Policy
-                    </option>
-                    <option value={ERC20_TRANSFER_POLICY_ADDRESS}>
-                      ERC20 Transfer Policy
-                    </option>
-                    <option value={MULTISEND_POLICY_ADDRESS}>
-                      Multisend Policy
-                    </option>
-                    <option value={NATIVE_TRANSFER_POLICY_ADDRESS}>
-                      Native Transfer Policy
-                    </option>
+                    {/* Write a for loop going through POLICY_ADDRESS_NAME */}
+                    {POLICY_ADDRESS_NAME.map(policy => (
+                      <option key={policy.address} value={policy.address}>
+                        {policy.name}
+                      </option>
+                    ))}
                   </Select>
                   <Button
                     variant="contained"

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -48,6 +48,13 @@ export const ALLOW_POLICY_ADDRESS = ethers.getAddress(
 )
 
 /**
+ * Deny Policy - Denies access to specified functions
+ */
+export const DENY_POLICY_ADDRESS = ethers.getAddress(
+  '0x0000000000000000000000000000000000000000'
+)
+
+/**
  * Allowed Module Policy - Controls which Safe modules can be used
  */
 export const ALLOWED_MODULE_POLICY_ADDRESS = ethers.getAddress(
@@ -153,22 +160,27 @@ export const MILLISECONDS_IN_SECOND = 1000n
 export const ZERO_SELECTOR = '0x00000000' as const
 
 /** List of known function selectors with their human-readable names */
-export const ADDRESS_NAME = [
-  { address: POLICY_ENGINE_ADDRESS, name: 'Policy Engine' },
+export const POLICY_ADDRESS_NAME = [
   { address: ALLOW_POLICY_ADDRESS, name: 'Allow Policy' },
+  { address: DENY_POLICY_ADDRESS, name: 'Deny Policy' },
   { address: ALLOWED_MODULE_POLICY_ADDRESS, name: 'Allowed Module Policy' },
   { address: COSIGNER_POLICY_ADDRESS, name: 'Cosigner Policy' },
   { address: ERC20_APPROVE_POLICY_ADDRESS, name: 'ERC20 Approve Policy' },
   { address: ERC20_TRANSFER_POLICY_ADDRESS, name: 'ERC20 Transfer Policy' },
   { address: MULTISEND_POLICY_ADDRESS, name: 'MultiSend Policy' },
   { address: NATIVE_TRANSFER_POLICY_ADDRESS, name: 'Native Transfer Policy' },
+]
+
+export const ADDRESS_NAME = [
+  ...POLICY_ADDRESS_NAME,
+  { address: POLICY_ENGINE_ADDRESS, name: 'Policy Engine' },
   { address: MULTISEND_CALL_ONLY, name: 'MultiSendCallOnly v1.4.1' },
   { address: ethers.ZeroAddress, name: 'Zero Address' },
 ]
 
 /** List of known function selectors with their human-readable names */
 export const SELECTOR_NAME = [
-  { selector: '0x00000000', name: 'Zero Selector' },
+  { selector: ZERO_SELECTOR, name: 'Zero Selector' },
   { selector: '0x8d80ff0a', name: 'multiSend(bytes)' },
   { selector: '0xa9059cbb', name: 'transfer(address,uint256)' },
   { selector: '0x095ea7b3', name: 'approve(address,uint256)' },

--- a/app/src/utils/helper.ts
+++ b/app/src/utils/helper.ts
@@ -21,6 +21,7 @@ import {
   ALLOWED_MODULE_POLICY_ADDRESS,
   CONTRACT_INTERFACE,
   COSIGNER_POLICY_ADDRESS,
+  DENY_POLICY_ADDRESS,
   ERC20_APPROVE_POLICY_ADDRESS,
   ERC20_TRANSFER_POLICY_ADDRESS,
   MULTISEND_POLICY_ADDRESS,
@@ -89,6 +90,7 @@ export function decodeData(policy: AddressLike, data: BytesLike): string {
   }
   if (
     policy == ALLOW_POLICY_ADDRESS ||
+    policy == DENY_POLICY_ADDRESS ||
     policy == MULTISEND_POLICY_ADDRESS ||
     policy == NATIVE_TRANSFER_POLICY_ADDRESS
   ) {


### PR DESCRIPTION
This pull request refactors how policy addresses and their display names are managed and improves the maintainability and scalability of the codebase. The main change is the introduction of a centralized `POLICY_ADDRESS_NAME` array, which is now used throughout the UI to dynamically render policy options, rather than hardcoding them. Additionally, a new "Deny Policy" is introduced, and the code is updated to support it in relevant places.

**Refactoring and maintainability improvements:**

* Replaced hardcoded policy options in the policy selection dropdown in `App.tsx` with a dynamic loop over `POLICY_ADDRESS_NAME`, making it easier to add or remove policies in the future.
* Updated imports and usages in `App.tsx` to use `POLICY_ADDRESS_NAME` instead of individual policy constants, simplifying the code and reducing the chance of errors.

**New feature support:**

* Added a new `DENY_POLICY_ADDRESS` constant in `constants.ts` to support a "Deny Policy" feature, and included it in `POLICY_ADDRESS_NAME` so it appears in the UI. [[1]](diffhunk://#diff-c8f039a2643bf4e7f9a3041882cb55651ec3499b897fea0249c2c555ea998f87R50-R56) [[2]](diffhunk://#diff-c8f039a2643bf4e7f9a3041882cb55651ec3499b897fea0249c2c555ea998f87L156-R183)
* Updated `decodeData` in `helper.ts` to handle the new `DENY_POLICY_ADDRESS` for decoding logic, ensuring correct behavior for this policy. [[1]](diffhunk://#diff-8028c1bc922ed402114ccd2352bfafd297c0c79341dda2cdfb4cdd5f29240768R24) [[2]](diffhunk://#diff-8028c1bc922ed402114ccd2352bfafd297c0c79341dda2cdfb4cdd5f29240768R93)

**Minor improvements:**

* Ensured consistent usage of the `ZERO_SELECTOR` constant throughout the codebase for fallback selectors. [[1]](diffhunk://#diff-5ecf765cce580a8f15211bbeed26b75d204a28efe8ccbcb0f669914150c303f6L497-R494) [[2]](diffhunk://#diff-c8f039a2643bf4e7f9a3041882cb55651ec3499b897fea0249c2c555ea998f87L156-R183)