### PR TITLE
Zero Address Default

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -459,6 +459,9 @@ function App() {
         return
       }
 
+      // If target is empty, set it to ZeroAddress (For fallback)
+      formData.target = formData.target ? formData.target : ZeroAddress
+
       // Validate 'target' address
       if (!isValidAddress(formData.target)) {
         setErrorMessage('Invalid "Target" address format')
@@ -788,7 +791,6 @@ function App() {
                     id="target"
                     name="target"
                     label="Target Address"
-                    required
                   />
                   <TextField
                     slotProps={{


### PR DESCRIPTION
## TLDR
If we want to add a fallback using the `setAllowedTx`, then we have to use the Zero Address, and for that to be used within the Safe App, we have to copy the Zero Address. This current change will make it easy to just leave the column blank, and the App will take care of adding it as a Zero Address automatically.

## LLM Description
This pull request makes a couple of changes to how the "Target Address" field is handled in the `App` component. The main update is to provide a fallback value for the target address and to adjust form validation logic accordingly.

Form logic improvements:

* If the `target` field is empty, it is now automatically set to `ZeroAddress` as a fallback before validation. This ensures that the form always has a valid default address, reducing the chance of errors.

Form UI changes:

* The `required` attribute has been removed from the "Target Address" input field, allowing the form to be submitted even if the user leaves it blank (since it will default to `ZeroAddress`).