### PR TITLE
`SignMessagePolicy` contract

### DIFF
--- a/contracts/policies/SignMessagePolicy.sol
+++ b/contracts/policies/SignMessagePolicy.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity =0.8.28;
+
+import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
+import {AccessSelector} from "../libraries/AccessSelector.sol";
+
+/**
+ * @title SignMessageLib interface
+ */
+interface ISignMessageLib {
+    function signMessage(bytes calldata _data) external;
+}
+
+/**
+ * @title SignMessage Policy
+ * @dev Allows only signMessage signatures.
+ */
+contract SignMessagePolicy is IPolicy {
+    using AccessSelector for AccessSelector.T;
+
+    /**
+     * @dev Struct representing a domain hash and primary type hash.
+     */
+    struct SignatureDomain {
+        bytes32 domainHash;
+        bytes32 primaryTypeHash;
+    }
+
+    /**
+     * @dev Mapping of allowed domain hashes and primary type hashes for each Safe.
+     */
+    // solhint-disable-next-line private-vars-leading-underscore
+    mapping(address safe => mapping(bytes32 domainHash => mapping(bytes32 primaryTypeHash => bool allowed)))
+        private _domains;
+
+    /**
+     * @dev Error indicating the domain or type hash is not allowed.
+     */
+    error DomainOrTypeNotAllowed();
+
+    /**
+     * @dev Error indicating the message hash is invalid.
+     */
+    error InvalidMsgHash();
+
+    /**
+     * @inheritdoc IPolicy
+     * @dev This policy always returns the magic value for a particular access selector.
+     */
+    function checkTransaction(
+        address safe,
+        address,
+        uint256,
+        bytes calldata data,
+        Operation,
+        bytes calldata context,
+        AccessSelector.T
+    ) external view override returns (bytes4 magicValue) {
+        (bytes32 domainHash, bytes32 primaryTypeHash, bytes memory structData) = abi.decode(
+            context,
+            (bytes32, bytes32, bytes)
+        );
+        require(_domains[safe][domainHash][primaryTypeHash], DomainOrTypeNotAllowed());
+        bytes32 messageHash = keccak256(
+            abi.encodePacked("\x19\x01", domainHash, keccak256(abi.encodePacked(primaryTypeHash, structData)))
+        );
+        bytes memory messageToSign = abi.decode(data[4:], (bytes));
+        require(
+            messageToSign.length == 32 && bytes32(abi.decode(messageToSign, (bytes32))) == messageHash,
+            InvalidMsgHash()
+        );
+        return IPolicy.checkTransaction.selector;
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     * @dev This policy requires configuration with allowed domain and type hashes.
+     */
+    function configure(address safe, AccessSelector.T selector, bytes memory data) external override returns (bool) {
+        SignatureDomain[] memory domains = abi.decode(data, (SignatureDomain[]));
+        for (uint256 i = 0; i < domains.length; i++) {
+            _domains[safe][domains[i].domainHash][domains[i].primaryTypeHash] = true;
+        }
+        return
+            selector.getOperation() == Operation.DELEGATECALL &&
+            selector.getSelector() == ISignMessageLib.signMessage.selector;
+    }
+}

--- a/contracts/policies/SignMessagePolicy.sol
+++ b/contracts/policies/SignMessagePolicy.sol
@@ -29,9 +29,9 @@ contract SignMessagePolicy is IPolicy {
     /**
      * @dev Mapping of allowed domain hashes and primary type hashes for each Safe.
      */
-    // solhint-disable-next-line private-vars-leading-underscore
-    mapping(address safe => mapping(bytes32 domainHash => mapping(bytes32 primaryTypeHash => bool allowed)))
-        private _domains;
+    // solhint-disable-next-line private-vars-leading-underscore, max-line-length
+    mapping(address policyGuard => mapping(address safe => mapping(bytes32 domainHash => mapping(bytes32 primaryTypeHash => bool allowed))))
+        private $domains;
 
     /**
      * @dev Error indicating the domain or type hash is not allowed.
@@ -60,7 +60,7 @@ contract SignMessagePolicy is IPolicy {
             context,
             (bytes32, bytes32, bytes)
         );
-        require(_domains[safe][domainHash][primaryTypeHash], DomainOrTypeNotAllowed());
+        require($domains[msg.sender][safe][domainHash][primaryTypeHash], DomainOrTypeNotAllowed());
         bytes32 messageHash = keccak256(
             abi.encodePacked("\x19\x01", domainHash, keccak256(abi.encodePacked(primaryTypeHash, structData)))
         );
@@ -79,7 +79,7 @@ contract SignMessagePolicy is IPolicy {
     function configure(address safe, AccessSelector.T selector, bytes memory data) external override returns (bool) {
         SignatureDomain[] memory domains = abi.decode(data, (SignatureDomain[]));
         for (uint256 i = 0; i < domains.length; i++) {
-            _domains[safe][domains[i].domainHash][domains[i].primaryTypeHash] = true;
+            $domains[msg.sender][safe][domains[i].domainHash][domains[i].primaryTypeHash] = true;
         }
         return
             selector.getOperation() == Operation.DELEGATECALL &&


### PR DESCRIPTION
## TLDR

Created a `signMessage` policy based on a Twitter reply: https://x.com/yodl_meister/status/1980580069480493279

To Do:

- [ ] Testing
- [ ] Deployment
- [ ] Safe App support

## LLM Description

This pull request introduces a new policy contract, `SignMessagePolicy`, which enforces strict rules for signing messages in the system. The contract ensures that only messages with explicitly allowed domain and type hashes can be signed, and validates the message hash before permitting the operation. The implementation includes error handling and configuration logic for managing allowed domains and types.

New policy contract for signing messages:

* Added `SignMessagePolicy` contract in `contracts/policies/SignMessagePolicy.sol`, enforcing that only `signMessage` operations with approved domain and type hashes are allowed.
* Implemented a mapping to store allowed domain and primary type hashes per Safe, ensuring granular control over permitted signatures.
* Added error handling for unauthorized domain/type hashes and invalid message hashes, improving security and debuggability.
* Provided configuration functionality to set allowed domain/type hashes for each Safe, enabling flexible policy management.