### PR TITLE
chore(deps): use published safe-smart-account ^1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nomicfoundation/ignition-core": "^0.15.11",
         "@openzeppelin/contracts": "^5.2.0",
         "@safe-global/safe-singleton-factory": "^1.0.41",
-        "@safe-global/safe-smart-account": "github:safe-global/safe-smart-account",
+        "@safe-global/safe-smart-account": "^1.5.0",
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "@typechain/ethers-v6": "^0.5.1",
         "@typechain/hardhat": "^9.1.0",
@@ -1839,8 +1839,9 @@
       "license": "MIT"
     },
     "node_modules/@safe-global/safe-smart-account": {
-      "version": "1.4.1-build.0",
-      "resolved": "git+ssh://git@github.com/safe-global/safe-smart-account.git#b115c4c5fe23dca6aefeeccc73d312ddd23322c2",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-smart-account/-/safe-smart-account-1.5.0.tgz",
+      "integrity": "sha512-VIMWxoeY/kNuZVsQVvAeOFKcQS3eojCXg0ecGnesBSLn5ypYshmBhVEEU5XiurJJGTs/MrcoLTbTxhs9W9GvdQ==",
       "dev": true,
       "license": "LGPL-3.0"
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@nomicfoundation/ignition-core": "^0.15.11",
     "@openzeppelin/contracts": "^5.2.0",
     "@safe-global/safe-singleton-factory": "^1.0.41",
-    "@safe-global/safe-smart-account": "github:safe-global/safe-smart-account",
+    "@safe-global/safe-smart-account": "^1.5.0",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@typechain/ethers-v6": "^0.5.1",
     "@typechain/hardhat": "^9.1.0",

--- a/test/deploy/SafeContracts.ts
+++ b/test/deploy/SafeContracts.ts
@@ -6,7 +6,6 @@ import CreateCallArtifact from '@safe-global/safe-smart-account/build/artifacts/
 import MultiSendArtifact from '@safe-global/safe-smart-account/build/artifacts/contracts/libraries/MultiSend.sol/MultiSend.json'
 import MultiSendCallOnlyArtifact from '@safe-global/safe-smart-account/build/artifacts/contracts/libraries/MultiSendCallOnly.sol/MultiSendCallOnly.json'
 import SafeMigrationArtifact from '@safe-global/safe-smart-account/build/artifacts/contracts/libraries/SafeMigration.sol/SafeMigration.json'
-import SafeToL2MigrationArtifact from '@safe-global/safe-smart-account/build/artifacts/contracts/libraries/SafeToL2Migration.sol/SafeToL2Migration.json'
 import SafeToL2SetupArtifact from '@safe-global/safe-smart-account/build/artifacts/contracts/libraries/SafeToL2Setup.sol/SafeToL2Setup.json'
 import SignMessageLibArtifact from '@safe-global/safe-smart-account/build/artifacts/contracts/libraries/SignMessageLib.sol/SignMessageLib.json'
 import SafeProxyFactoryArtifact from '@safe-global/safe-smart-account/build/artifacts/contracts/proxies/SafeProxyFactory.sol/SafeProxyFactory.json'
@@ -34,7 +33,6 @@ export async function deploy() {
     safeL2.target,
     compatibilityFallbackHandler.target
   ])
-  const safeToL2Migration = await deployArtifact(SafeToL2MigrationArtifact)
   const safeToL2Setup = await deployArtifact(SafeToL2SetupArtifact)
   const signMessageLib = await deployArtifact(SignMessageLibArtifact)
   const safeProxyFactory = (await deployArtifact(SafeProxyFactoryArtifact)) as unknown as SafeProxyFactory
@@ -48,7 +46,6 @@ export async function deploy() {
     multiSend,
     multiSendCallOnly,
     safeMigration,
-    safeToL2Migration,
     safeToL2Setup,
     signMessageLib,
     safeProxyFactory


### PR DESCRIPTION
Replace the `github:` git dependency with the published `^1.5.0` package.

## Context and Motivation

The git dependency builds itself on install; its `build:zk` step downloads compilers via an old Hardhat/undici that rejects redirects, so `npm ci` fails regardless of connectivity. The published 1.5.0 package ships prebuilt artifacts and runs no compile on install.

## Decisions and Tradeoffs

Released 1.5.0 dropped the (unused) `SafeToL2Migration`, so it is removed from the test deployment fixture. Only 1.5.0 is published on npm, and it carries the module-guard features the tests rely on.

## Testing

`npm run build`, `lint`, and `test` all green (75 passing).
