### PR TITLE
feat(guard): require safeTxGas == 0

### DIFF
--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -60,6 +60,11 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
     error NonZeroGasPrice();
 
     /**
+     * @notice Error indicating non zero safe transaction gas is not allowed.
+     */
+    error NonZeroSafeTxGas();
+
+    /**
      * @notice Error indicating the root is not configured.
      * @param root The root that is not configured.
      */
@@ -137,7 +142,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         uint256 value,
         bytes calldata data,
         Operation operation,
-        uint256,
+        uint256 safeTxGas,
         uint256,
         uint256 gasPrice,
         address,
@@ -150,6 +155,12 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         // transaction that is rarely used, and therefore should not be covered by the access
         // control system.
         require(gasPrice == 0, NonZeroGasPrice());
+
+        // A non-zero `safeTxGas` lets a Safe transaction whose inner call fails complete without
+        // reverting. Once policy checks can mutate state, that would commit any state a policy
+        // staged during the pre-check against a failed action. Forbid it so a failed execution
+        // always reverts atomically, keeping policy state in sync with execution outcome.
+        require(safeTxGas == 0, NonZeroSafeTxGas());
 
         checkTransaction(msg.sender, to, value, data, operation, _decodeContext(signatures));
     }

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -813,6 +813,32 @@ describe('SafePolicyGuard', function () {
         .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
         .withArgs(ZeroAddress)
     })
+
+    it('Should revert when safeTxGas is non-zero', async function () {
+      const { safePolicyGuard } = await loadFixture(fixture)
+
+      // A non-zero `safeTxGas` must be rejected before any policy lookup. Call the transaction
+      // guard entry point directly so the revert originates in the guard (not routed through a
+      // full Safe execution).
+      const checkTransaction = safePolicyGuard.getFunction(
+        'checkTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes,address)'
+      )
+      await expect(
+        checkTransaction(
+          randomAddress(),
+          0n,
+          '0x',
+          SafeOperation.Call,
+          1n,
+          0n,
+          0n,
+          ZeroAddress,
+          ZeroAddress,
+          '0x',
+          ZeroAddress
+        )
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'NonZeroSafeTxGas')
+    })
   })
 
   describe('checkModuleTransaction', function () {


### PR DESCRIPTION
Reject a non-zero `safeTxGas` in the transaction-guard entry.

## Context and Motivation

Mirrors the existing `gasPrice == 0` rule. A non-zero `safeTxGas` lets a Safe transaction whose inner call fails complete without reverting; once policy checks can mutate state (subsequent PRs), that would commit state a policy staged during the pre-check against a failed action. Forbidding it keeps failed execution atomic, so a policy's staged state stays consistent with the execution outcome.

## Testing

New unit test asserting `NonZeroSafeTxGas` via a direct guard-entry call. Suite 76 passing.