### PR TITLE
test: reentrancy and stateful-check suite for the non-view path

### DIFF
--- a/contracts/test/ReentrantMockPolicy.sol
+++ b/contracts/test/ReentrantMockPolicy.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.28;
+
+import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
+import {IPolicyEngine} from "../interfaces/IPolicyEngine.sol";
+import {ISafeTransactionGuard} from "../interfaces/ISafeTransactionGuard.sol";
+import {AccessSelector} from "../libraries/AccessSelector.sol";
+
+/**
+ * @title Reentrant Mock Policy
+ * @dev Test-only policy that exercises the non-`view` check path guards. During its
+ *      `checkTransaction` it performs an action selected by `mode`:
+ *      - `ReenterGuardEntry`: re-enters the transaction-guard entry (as a Safe reentry would)
+ *        — expected to be blocked by `Reentrancy`.
+ *      - `ReenterEngine`: re-enters the engine `checkTransaction` for `reenterSafe`/`reenterTo`
+ *        — used to test both the blocked cross-Safe case (`reenterSafe` != the checked Safe) and
+ *        the allowed same-Safe case (`reenterSafe` == the checked Safe, the `MultiSendPolicy`
+ *        mechanism).
+ *      - `WriteState`: mutates its own state, to stand in for a stateful policy and to prove
+ *        stateful writes commit.
+ *      For the re-entry modes it catches any revert and records the returned error data (and
+ *      whether the re-entry succeeded) so tests can assert which guard fired, then returns the
+ *      magic value so the outer check still succeeds.
+ */
+contract ReentrantMockPolicy is IPolicy {
+    enum Mode {
+        None,
+        ReenterGuardEntry,
+        ReenterEngine,
+        WriteState
+    }
+
+    Mode public mode;
+    address public reenterSafe;
+    address public reenterTo;
+    uint256 public writes;
+    bytes public lastReentryError;
+    bool public reenterSucceeded;
+
+    /**
+     * @notice Thrown if a reentry attempt unexpectedly succeeds (the guard failed to block it).
+     */
+    error ReentryDidNotRevert();
+
+    function setMode(Mode mode_) external {
+        mode = mode_;
+    }
+
+    function setReenter(address reenterSafe_, address reenterTo_) external {
+        reenterSafe = reenterSafe_;
+        reenterTo = reenterTo_;
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     */
+    function checkTransaction(
+        address,
+        address to,
+        uint256 value,
+        bytes calldata data,
+        Operation operation,
+        bytes calldata,
+        AccessSelector.T
+    ) external override returns (bytes4 magicValue) {
+        if (mode == Mode.ReenterGuardEntry) {
+            try
+                ISafeTransactionGuard(msg.sender).checkTransaction(
+                    to,
+                    value,
+                    data,
+                    operation,
+                    0,
+                    0,
+                    0,
+                    address(0),
+                    payable(address(0)),
+                    hex"",
+                    address(0)
+                )
+            {
+                revert ReentryDidNotRevert();
+            } catch (bytes memory err) {
+                lastReentryError = err;
+            }
+        } else if (mode == Mode.ReenterEngine) {
+            try IPolicyEngine(msg.sender).checkTransaction(reenterSafe, reenterTo, 0, hex"", operation, hex"") returns (
+                address
+            ) {
+                reenterSucceeded = true;
+            } catch (bytes memory err) {
+                lastReentryError = err;
+            }
+        } else if (mode == Mode.WriteState) {
+            writes++;
+        }
+
+        return IPolicy.checkTransaction.selector;
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     */
+    function configure(address, AccessSelector.T, bytes memory) external pure override returns (bool) {
+        return true;
+    }
+}

--- a/test/reentrancy.spec.ts
+++ b/test/reentrancy.spec.ts
@@ -1,0 +1,152 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai'
+import { ZeroAddress, id } from 'ethers'
+import { ethers } from 'hardhat'
+
+import { createConfiguration, createSafe, execTransaction, randomAddress } from '../src/utils'
+import { deploySafeContracts, deploySafePolicyGuard } from './deploy'
+
+// Mirrors ReentrantMockPolicy.Mode.
+enum Mode {
+  None,
+  ReenterGuardEntry,
+  ReenterEngine,
+  WriteState
+}
+
+describe('Non-view check path — reentrancy & Safe confinement', function () {
+  async function deployReentrantPolicy() {
+    return await (await ethers.getContractFactory('ReentrantMockPolicy')).deploy()
+  }
+
+  async function fixture() {
+    const [, ownerA, ownerB] = await ethers.getSigners()
+
+    const { safePolicyGuard } = await deploySafePolicyGuard()
+    const { safeProxyFactory, safe: safeSingleton } = await deploySafeContracts()
+    const safeA = await createSafe({
+      owner: ownerA,
+      guard: ZeroAddress,
+      saltNonce: BigInt(0xa1),
+      safeProxyFactory,
+      singleton: safeSingleton
+    })
+    const safeB = await createSafe({
+      owner: ownerB,
+      guard: ZeroAddress,
+      saltNonce: BigInt(0xb2),
+      safeProxyFactory,
+      singleton: safeSingleton
+    })
+
+    return { ownerA, ownerB, safePolicyGuard, safeA, safeB }
+  }
+
+  // Configures `policy` for `owner`'s Safe (via configureImmediately) using the given
+  // configuration overrides, then enables the guard on that Safe.
+  async function configureAndEnableGuard(owner: any, safe: any, safePolicyGuard: any, configurations: any[]) {
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: await safePolicyGuard.getAddress(),
+      data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+    })
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: await safe.getAddress(),
+      data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+    })
+  }
+
+  it('Should block a policy re-entering the guard during a check (Reentrancy)', async function () {
+    const { ownerA, safePolicyGuard, safeA } = await loadFixture(fixture)
+
+    const x = await deployReentrantPolicy()
+    await x.setMode(Mode.ReenterGuardEntry)
+    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
+      createConfiguration({ policy: await x.getAddress() })
+    ])
+
+    // Outer tx succeeds: the policy catches the (blocked) reentry and returns the magic value.
+    await execTransaction({ owners: [ownerA], safe: safeA, to: randomAddress() })
+
+    expect((await x.lastReentryError()).slice(0, 10)).to.equal(id('Reentrancy()').slice(0, 10))
+  })
+
+  it("Should NOT let a malicious policy on Safe A consume another Safe B's policy state (CrossSafeCheck)", async function () {
+    const { ownerA, ownerB, safePolicyGuard, safeA, safeB } = await loadFixture(fixture)
+
+    // Safe B has a real stateful policy Y (its fallback) that counts every check it receives.
+    const policyY = await deployReentrantPolicy()
+    await policyY.setMode(Mode.WriteState)
+    await execTransaction({
+      owners: [ownerB],
+      safe: safeB,
+      to: await safePolicyGuard.getAddress(),
+      data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+        [createConfiguration({ policy: await policyY.getAddress() })]
+      ])
+    })
+
+    // Safe A has a malicious policy X that re-enters the engine hardcoding safe = Safe B,
+    // attempting to drive (and consume) Safe B's policy Y.
+    const policyX = await deployReentrantPolicy()
+    await policyX.setMode(Mode.ReenterEngine)
+    await policyX.setReenter(await safeB.getAddress(), randomAddress())
+    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
+      createConfiguration({ policy: await policyX.getAddress() })
+    ])
+
+    // Safe A executes; X tries to drive a check for Safe B mid-check.
+    await execTransaction({ owners: [ownerA], safe: safeA, to: randomAddress() })
+
+    // The cross-Safe re-entry was rejected by CrossSafeCheck ...
+    expect((await policyX.lastReentryError()).slice(0, 10)).to.equal(id('CrossSafeCheck()').slice(0, 10))
+    expect(await policyX.reenterSucceeded()).to.equal(false)
+    // ... and Safe B's policy state was never touched.
+    expect(await policyY.writes()).to.equal(0n)
+  })
+
+  it('Should allow same-Safe re-invocation by design (the MultiSendPolicy mechanism)', async function () {
+    const { ownerA, safePolicyGuard, safeA } = await loadFixture(fixture)
+
+    const targetX = randomAddress() // outer target -> policy X
+    const targetZ = randomAddress() // re-entry target -> policy Z
+
+    // Z: a benign stateful policy on Safe A for `targetZ`.
+    const policyZ = await deployReentrantPolicy()
+    await policyZ.setMode(Mode.WriteState)
+
+    // X: re-enters the engine for the SAME Safe A, targeting `targetZ` (-> policy Z).
+    const policyX = await deployReentrantPolicy()
+    await policyX.setMode(Mode.ReenterEngine)
+    await policyX.setReenter(await safeA.getAddress(), targetZ)
+
+    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
+      createConfiguration({ target: targetX, policy: await policyX.getAddress() }),
+      createConfiguration({ target: targetZ, policy: await policyZ.getAddress() })
+    ])
+
+    // Safe A executes a tx to targetX -> X -> re-enters the engine for A/targetZ -> Z.
+    await execTransaction({ owners: [ownerA], safe: safeA, to: targetX })
+
+    // Same-Safe re-invocation is permitted and reaches A's other policy, confined to Safe A.
+    expect(await policyX.reenterSucceeded()).to.equal(true)
+    expect(await policyZ.writes()).to.equal(1n)
+  })
+
+  it('Should commit state a policy writes during a successful check', async function () {
+    const { ownerA, safePolicyGuard, safeA } = await loadFixture(fixture)
+
+    const policy = await deployReentrantPolicy()
+    await policy.setMode(Mode.WriteState)
+    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
+      createConfiguration({ policy: await policy.getAddress() })
+    ])
+
+    expect(await policy.writes()).to.equal(0n)
+    await execTransaction({ owners: [ownerA], safe: safeA, to: randomAddress() })
+    expect(await policy.writes()).to.equal(1n)
+  })
+})


### PR DESCRIPTION
Adversarial tests for the guards added in the previous PR.

## Context and Motivation

Exercises the security-critical behavior of the non-`view` check path.

## Decisions and Tradeoffs

A test-only `ReentrantMockPolicy` attempts reentries during its check, catches the revert, and records the returned error so the spec can assert which guard fired (the engine's `try/catch` would otherwise mask it as `AccessDenied`). The gas benchmark is unchanged — it only logs gas, with no hardcoded assertions.

## Testing

`Reentrancy` (a policy reentering the guard mid-check is blocked), `CrossSafeCheck` (a policy driving a check for another Safe is blocked), and state-commit-on-success. Suite 80 passing.