### PR TITLE
feat: make policy check path non-view with reentrancy gate

### DIFF
--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -149,7 +149,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         address payable,
         bytes calldata signatures,
         address
-    ) external view override {
+    ) external override {
         // TODO(nlordell): To simplify policies, we do not support gas prices for transaction
         // execution payment. This would add another mechanism for extracting funds from a Safe
         // transaction that is rarely used, and therefore should not be covered by the access
@@ -162,7 +162,9 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         // always reverts atomically, keeping policy state in sync with execution outcome.
         require(safeTxGas == 0, NonZeroSafeTxGas());
 
+        _enterCheck(msg.sender);
         checkTransaction(msg.sender, to, value, data, operation, _decodeContext(signatures));
+        _exitCheck();
     }
 
     /* solhint-disable no-empty-blocks */
@@ -181,8 +183,10 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         bytes calldata data,
         Operation operation,
         address module
-    ) external view override returns (bytes32 moduleTxHash) {
+    ) external override returns (bytes32 moduleTxHash) {
+        _enterCheck(msg.sender);
         checkTransaction(msg.sender, to, value, data, operation, abi.encode(module));
+        _exitCheck();
         return bytes32(0);
     }
 

--- a/contracts/core/PolicyEngine.sol
+++ b/contracts/core/PolicyEngine.sol
@@ -24,9 +24,34 @@ abstract contract PolicyEngine is IPolicyEngine {
     mapping(address safe => mapping(AccessSelector.T => address policy)) private $policies;
 
     /**
+     * @notice The Safe currently being checked, or `address(0)` when no check is in progress.
+     * @dev Doubles as the reentrancy sentinel (non-zero => a top-level check is in progress) and
+     *      as the identity used to confine recursive checks to the checked Safe. A top-level check
+     *      is always entered with `msg.sender` (a deployed Safe), which is never `address(0)`.
+     *      TODO: move to transient storage (EIP-1153) once all target chains support it.
+     */
+    // solhint-disable-next-line private-vars-leading-underscore
+    address private $checkingSafe;
+
+    /**
      * @notice Error indicating an invalid selector was provided.
      */
     error InvalidSelector();
+
+    /**
+     * @notice Error indicating a reentrant top-level check was attempted.
+     */
+    error Reentrancy();
+
+    /**
+     * @notice Error indicating `checkTransaction` was called outside of a top-level guard check.
+     */
+    error NotChecking();
+
+    /**
+     * @notice Error indicating a check was requested for a Safe other than the one being checked.
+     */
+    error CrossSafeCheck();
 
     /**
      * @notice Error indicating access was denied.
@@ -118,7 +143,20 @@ abstract contract PolicyEngine is IPolicyEngine {
         bytes calldata data,
         Operation operation,
         bytes memory context
-    ) public view virtual returns (address) {
+    ) public virtual returns (address) {
+        // Intentionally `public`: this is invoked both internally by the guard entry points
+        // (`checkTransaction(msg.sender, ...)`) and externally by a policy recursing during a
+        // check (e.g. `MultiSendPolicy` validating each sub-transaction). The checks below do NOT
+        // block external calls — they constrain *when* and *for which Safe* it may run:
+        //  - `NotChecking`: only while a top-level check is in progress. `$checkingSafe` is set by
+        //    `_enterCheck` at the guard entry and cleared on exit, so a standalone call reverts.
+        //  - `CrossSafeCheck`: only for the Safe currently being checked, so a re-entrant or
+        //    cross-policy call cannot drive a check for a different Safe.
+        // `msg.sender` is deliberately not checked: the legitimate re-entrant (external) caller is
+        // a policy whose address is not known in advance.
+        require($checkingSafe != address(0), NotChecking());
+        require(safe == $checkingSafe, CrossSafeCheck());
+
         if (_allowedCalls(to, value, data, operation)) {
             return address(0);
         }
@@ -133,6 +171,28 @@ abstract contract PolicyEngine is IPolicyEngine {
             revert AccessDenied(policy);
         }
         return policy;
+    }
+
+    /**
+     * @notice Begins a top-level guard check for `safe`, guarding against reentrancy.
+     * @dev Reverts if a top-level check is already in progress. Since the Safe invokes the guard on
+     *      every execution, this also stops a policy from re-entering the Safe to run another
+     *      guarded transaction mid-check. It does not by itself restrict calls to the configuration
+     *      functions — those stay safe because their state is keyed by `msg.sender`. Kept as shared
+     *      functions rather than a modifier to avoid duplicating the guard bytecode at each entry.
+     */
+    function _enterCheck(address safe) internal {
+        require($checkingSafe == address(0), Reentrancy());
+        $checkingSafe = safe;
+    }
+
+    /**
+     * @notice Ends the top-level guard check.
+     * @dev Must run before the entry point returns; the reset is required because `$checkingSafe`
+     *      is persistent storage (removable once it moves to transient storage).
+     */
+    function _exitCheck() internal {
+        $checkingSafe = address(0);
     }
 
     /**

--- a/contracts/interfaces/IPolicy.sol
+++ b/contracts/interfaces/IPolicy.sol
@@ -17,7 +17,15 @@ interface IPolicy {
      * @param operation The type of operation of the transaction.
      * @param context The context of the transaction.
      * @param access The access selector for the transaction.
-     * @dev The function needs to implement policy validation logic (if any).
+     * @dev Implements the policy validation logic. This function MAY mutate state (stateful
+     *      policies are supported). To preserve the security properties the engine relies on,
+     *      policy authors MUST:
+     *      1. Prefer no external calls; if reading external state, use a `STATICCALL` (e.g. a
+     *         `view` helper) so the callee cannot reenter.
+     *      2. Never make a state-mutating external call to an untrusted address during the check.
+     *      3. Key state by `msg.sender` (the calling engine/guard) and treat `safe` as untrusted
+     *         input — i.e. namespace storage as `(msg.sender, safe)` — to avoid cross-guard interference.
+     *      4. Follow checks-effects-interactions and bound gas/storage growth.
      */
     function checkTransaction(
         address safe,
@@ -27,7 +35,7 @@ interface IPolicy {
         Operation operation,
         bytes calldata context,
         AccessSelector.T access
-    ) external view returns (bytes4 magicValue);
+    ) external returns (bytes4 magicValue);
 
     /**
      * @notice Configures the policy.

--- a/contracts/interfaces/IPolicyEngine.sol
+++ b/contracts/interfaces/IPolicyEngine.sol
@@ -41,5 +41,5 @@ interface IPolicyEngine {
         bytes calldata data,
         Operation operation,
         bytes memory context
-    ) external view returns (address);
+    ) external returns (address);
 }

--- a/contracts/policies/ERC20ApprovePolicy.sol
+++ b/contracts/policies/ERC20ApprovePolicy.sol
@@ -78,7 +78,7 @@ contract ERC20ApprovePolicy is IPolicy {
      * @param safe The Safe address.
      * @param access The access selector.
      * @param data The spender address.
-     * @dev This can only be called by the Safe Policy Guard.
+     * @dev Callable by anyone; state is namespaced by `msg.sender`, keeping the policy engine and policies logically separate.
      */
     function configure(address safe, AccessSelector.T access, bytes memory data) external returns (bool) {
         bytes4 selector = access.getSelector();

--- a/contracts/policies/ERC20TransferPolicy.sol
+++ b/contracts/policies/ERC20TransferPolicy.sol
@@ -81,7 +81,7 @@ contract ERC20TransferPolicy is IPolicy {
      * @param safe The Safe address.
      * @param access The access selector.
      * @param data The recipient address.
-     * @dev This can only be called by the Safe Policy Guard.
+     * @dev Callable by anyone; state is namespaced by `msg.sender`, keeping the policy engine and policies logically separate.
      */
     function configure(address safe, AccessSelector.T access, bytes memory data) external returns (bool) {
         bytes4 selector = access.getSelector();

--- a/contracts/policies/MultiSendPolicy.sol
+++ b/contracts/policies/MultiSendPolicy.sol
@@ -15,6 +15,9 @@ contract MultiSendPolicy is IPolicy {
 
     error InvalidMultiSend();
 
+    // Not `view`: this policy performs no writes itself, but it recurses into the (now non-`view`)
+    // engine `checkTransaction` for each sub-transaction, which a `view` function cannot call. The
+    // recursion passes the same `safe`, so it satisfies the engine's same-Safe confinement.
     function checkTransaction(
         address safe,
         address to,
@@ -23,7 +26,7 @@ contract MultiSendPolicy is IPolicy {
         Operation operation,
         bytes calldata context,
         AccessSelector.T
-    ) external view override returns (bytes4 magicValue) {
+    ) external override returns (bytes4 magicValue) {
         bytes calldata transactions = _decodeMultiSendTransactions(data);
         bytes calldata ctx;
         while (transactions.length > 0) {

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -839,6 +839,17 @@ describe('SafePolicyGuard', function () {
         )
       ).to.be.revertedWithCustomError(safePolicyGuard, 'NonZeroSafeTxGas')
     })
+
+    it('Should revert a direct engine checkTransaction outside a top-level check (NotChecking)', async function () {
+      const { safePolicyGuard, safe } = await loadFixture(fixture)
+
+      // The engine `checkTransaction` (6-arg) is only reachable while a top-level guard check is
+      // in progress. Calling it directly (no `_enterCheck`) must revert.
+      const engineCheck = safePolicyGuard.getFunction('checkTransaction(address,address,uint256,bytes,uint8,bytes)')
+      await expect(
+        engineCheck(await safe.getAddress(), randomAddress(), 0n, '0x', SafeOperation.Call, '0x')
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'NotChecking')
+    })
   })
 
   describe('checkModuleTransaction', function () {


### PR DESCRIPTION
Drop `view` from the check path and add the guards that replace the lost `STATICCALL` sandbox.

## Context and Motivation

Enables stateful policies. Removing `view` from `IPolicy`, `IPolicyEngine`, `PolicyEngine.checkTransaction`, and the `SafePolicyGuard` transaction- and module-guard entries turns the engine→policy `STATICCALL` into a `CALL`, reintroducing reentrancy; the guards below neutralize it.

## Decisions and Tradeoffs

- A single `$checkingSafe` slot doubles as the reentrancy sentinel and the checked-Safe identity (persistent storage for now; a follow-up can move it to EIP-1153 transient storage).
- Shared `_enterCheck`/`_exitCheck` internal functions (not a modifier) avoid duplicating the guard bytecode at each entry point.
- The engine `checkTransaction` is gated by `NotChecking` (reachable only during a top-level check) and `CrossSafeCheck` (`safe == $checkingSafe`), confining recursion and cross-policy calls to the checked Safe — so a policy configured on one Safe cannot mutate another Safe's state. `MultiSendPolicy` recurses with the same Safe, so it is unaffected.
- `MultiSendPolicy` becomes non-`view`; all other policies stay `view`/`pure` (valid tighter overrides). The policy-author security contract is added to `IPolicy` NatSpec.

## Testing

Smoke test for the `NotChecking` gate; all existing MultiSend recursion tests still pass. Suite 77 passing.