### PR TITLE
feat: pass the authorizing module to policies out-of-band

### DIFF
--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -162,7 +162,8 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         // always reverts atomically, keeping policy state in sync with execution outcome.
         require(safeTxGas == 0, NonZeroSafeTxGas());
 
-        _enterCheck(msg.sender);
+        // An owner transaction has no authorizing module.
+        _enterCheck(msg.sender, address(0));
         checkTransaction(msg.sender, to, value, data, operation, _decodeContext(signatures));
         _exitCheck();
     }
@@ -184,8 +185,10 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         Operation operation,
         address module
     ) external override returns (bytes32 moduleTxHash) {
-        _enterCheck(msg.sender);
-        checkTransaction(msg.sender, to, value, data, operation, abi.encode(module));
+        // The module travels out-of-band so policies receive it authenticated; passing it through
+        // `context` let any executor forge a module identity from the Safe `signatures`.
+        _enterCheck(msg.sender, module);
+        checkTransaction(msg.sender, to, value, data, operation, _emptyContext());
         _exitCheck();
         return bytes32(0);
     }

--- a/contracts/core/PolicyEngine.sol
+++ b/contracts/core/PolicyEngine.sol
@@ -34,6 +34,16 @@ abstract contract PolicyEngine is IPolicyEngine {
     address private $checkingSafe;
 
     /**
+     * @notice The module that authorized the check in progress, or `address(0)` for an owner
+     *         transaction (and whenever no check is in progress).
+     * @dev Held in state rather than passed as a `checkTransaction` argument so that a policy
+     *      driving a recursive check cannot forge the authorization path it is checked under.
+     *      TODO: move to transient storage (EIP-1153) once all target chains support it.
+     */
+    // solhint-disable-next-line private-vars-leading-underscore
+    address private $checkingModule;
+
+    /**
      * @notice Error indicating an invalid selector was provided.
      */
     error InvalidSelector();
@@ -163,9 +173,10 @@ abstract contract PolicyEngine is IPolicyEngine {
 
         (AccessSelector.T access, address policy) = getPolicy(safe, to, data, operation);
         require(policy != address(0), AccessDenied(address(0)));
-        try IPolicy(policy).checkTransaction(safe, to, value, data, operation, context, access) returns (
-            bytes4 magicValue
-        ) {
+        // The module comes from state, not from the caller — see `$checkingModule`.
+        try
+            IPolicy(policy).checkTransaction(safe, to, value, data, operation, $checkingModule, context, access)
+        returns (bytes4 magicValue) {
             require(magicValue == IPolicy.checkTransaction.selector, AccessDenied(policy));
         } catch {
             revert AccessDenied(policy);
@@ -175,24 +186,30 @@ abstract contract PolicyEngine is IPolicyEngine {
 
     /**
      * @notice Begins a top-level guard check for `safe`, guarding against reentrancy.
+     * @param safe The Safe being checked.
+     * @param module The module authorizing the transaction, or `address(0)` for an owner transaction.
      * @dev Reverts if a top-level check is already in progress. Since the Safe invokes the guard on
      *      every execution, this also stops a policy from re-entering the Safe to run another
      *      guarded transaction mid-check. It does not by itself restrict calls to the configuration
      *      functions — those stay safe because their state is keyed by `msg.sender`. Kept as shared
      *      functions rather than a modifier to avoid duplicating the guard bytecode at each entry.
      */
-    function _enterCheck(address safe) internal {
+    function _enterCheck(address safe, address module) internal {
         require($checkingSafe == address(0), Reentrancy());
         $checkingSafe = safe;
+        $checkingModule = module;
     }
 
     /**
      * @notice Ends the top-level guard check.
-     * @dev Must run before the entry point returns; the reset is required because `$checkingSafe`
-     *      is persistent storage (removable once it moves to transient storage).
+     * @dev Must run before the entry point returns; the reset is required because the fields are
+     *      persistent storage (removable once they move to transient storage). Clearing
+     *      `$checkingModule` keeps it `address(0)` outside a check, so an owner transaction can
+     *      never observe a stale module.
      */
     function _exitCheck() internal {
         $checkingSafe = address(0);
+        $checkingModule = address(0);
     }
 
     /**

--- a/contracts/interfaces/IPolicy.sol
+++ b/contracts/interfaces/IPolicy.sol
@@ -15,7 +15,13 @@ interface IPolicy {
      * @param value The value of the transaction in Wei.
      * @param data The transaction data.
      * @param operation The type of operation of the transaction.
-     * @param context The context of the transaction.
+     * @param module The module that authorized the transaction, or `address(0)` for an owner
+     *        transaction. The engine sources this from the guard entry point and not from `context`,
+     *        so unlike `context` it can be trusted.
+     * @param context Additional caller-supplied data, **untrusted on every path**: on the
+     *        transaction path any executor can choose it (the Safe transaction hash does not cover
+     *        `signatures`), and on the module path it is always empty. Never treat it as an identity
+     *        claim — use `module` for that.
      * @param access The access selector for the transaction.
      * @dev Implements the policy validation logic. This function MAY mutate state (stateful
      *      policies are supported). To preserve the security properties the engine relies on,
@@ -33,6 +39,7 @@ interface IPolicy {
         uint256 value,
         bytes calldata data,
         Operation operation,
+        address module,
         bytes calldata context,
         AccessSelector.T access
     ) external returns (bytes4 magicValue);

--- a/contracts/policies/AllowPolicy.sol
+++ b/contracts/policies/AllowPolicy.sol
@@ -19,6 +19,7 @@ contract AllowPolicy is IPolicy {
         uint256,
         bytes calldata,
         Operation,
+        address,
         bytes calldata,
         AccessSelector.T
     ) external pure override returns (bytes4 magicValue) {

--- a/contracts/policies/AllowedModulePolicy.sol
+++ b/contracts/policies/AllowedModulePolicy.sol
@@ -28,7 +28,9 @@ contract AllowedModulePolicy is IPolicy {
 
     /**
      * @inheritdoc IPolicy
-     * @dev This policy returns the magic value if it is an allowed module.
+     * @dev This policy returns the magic value if it is an allowed module. The zero check confines
+     *      it to the module path, since `module` is engine-supplied and `address(0)` for owner
+     *      transactions. Never read the module from `context`, which any executor can choose.
      */
     function checkTransaction(
         address safe,
@@ -36,11 +38,11 @@ contract AllowedModulePolicy is IPolicy {
         uint256,
         bytes calldata,
         Operation,
-        bytes calldata context,
+        address module,
+        bytes calldata,
         AccessSelector.T
     ) external view override returns (bytes4 magicValue) {
-        address module = abi.decode(context, (address));
-
+        require(module != address(0), InvalidModule());
         require($allowedModules[msg.sender][safe][module], UnauthorizedModule());
 
         return IPolicy.checkTransaction.selector;
@@ -53,6 +55,8 @@ contract AllowedModulePolicy is IPolicy {
      */
     function configure(address safe, AccessSelector.T, bytes memory data) external override returns (bool) {
         address module = abi.decode(data, (address));
+        // A zero entry would match every owner transaction, making this policy an allow-all.
+        require(module != address(0), InvalidModule());
 
         $allowedModules[msg.sender][safe][module] = true;
 

--- a/contracts/policies/CoSignerPolicy.sol
+++ b/contracts/policies/CoSignerPolicy.sol
@@ -28,6 +28,7 @@ contract CoSignerPolicy is IPolicy {
         uint256 value,
         bytes calldata data,
         Operation operation,
+        address,
         bytes calldata context,
         AccessSelector.T access
     ) external view override returns (bytes4 magicValue) {

--- a/contracts/policies/DenyPolicy.sol
+++ b/contracts/policies/DenyPolicy.sol
@@ -21,6 +21,7 @@ contract DenyPolicy is IPolicy {
         uint256,
         bytes calldata,
         Operation,
+        address,
         bytes calldata,
         AccessSelector.T
     ) external pure override returns (bytes4 magicValue) {}

--- a/contracts/policies/ERC20ApprovePolicy.sol
+++ b/contracts/policies/ERC20ApprovePolicy.sol
@@ -55,6 +55,7 @@ contract ERC20ApprovePolicy is IPolicy {
         uint256,
         bytes calldata data,
         Operation,
+        address,
         bytes calldata,
         AccessSelector.T
     ) external view override returns (bytes4 magicValue) {

--- a/contracts/policies/ERC20TransferPolicy.sol
+++ b/contracts/policies/ERC20TransferPolicy.sol
@@ -55,6 +55,7 @@ contract ERC20TransferPolicy is IPolicy {
         uint256,
         bytes calldata data,
         Operation,
+        address,
         bytes calldata,
         AccessSelector.T
     ) external view override returns (bytes4 magicValue) {

--- a/contracts/policies/MultiSendPolicy.sol
+++ b/contracts/policies/MultiSendPolicy.sol
@@ -18,12 +18,16 @@ contract MultiSendPolicy is IPolicy {
     // Not `view`: this policy performs no writes itself, but it recurses into the (now non-`view`)
     // engine `checkTransaction` for each sub-transaction, which a `view` function cannot call. The
     // recursion passes the same `safe`, so it satisfies the engine's same-Safe confinement.
+    //
+    // `module` is intentionally not forwarded: the engine reads it from its own state for recursive
+    // checks too, so sub-transactions inherit the batch's authorization path.
     function checkTransaction(
         address safe,
         address to,
         uint256 value,
         bytes calldata data,
         Operation operation,
+        address,
         bytes calldata context,
         AccessSelector.T
     ) external override returns (bytes4 magicValue) {

--- a/contracts/policies/NativeTransferPolicy.sol
+++ b/contracts/policies/NativeTransferPolicy.sol
@@ -19,6 +19,7 @@ contract NativeTransferPolicy is IPolicy {
         uint256 value,
         bytes calldata,
         Operation,
+        address,
         bytes calldata,
         AccessSelector.T
     ) external pure override returns (bytes4 magicValue) {

--- a/contracts/test/MockPolicy.sol
+++ b/contracts/test/MockPolicy.sol
@@ -41,6 +41,7 @@ contract MockPolicy is IPolicy {
         uint256,
         bytes calldata,
         Operation,
+        address,
         bytes calldata,
         AccessSelector.T
     ) external view override returns (bytes4 magicValue) {

--- a/contracts/test/ReentrantMockPolicy.sol
+++ b/contracts/test/ReentrantMockPolicy.sol
@@ -60,6 +60,7 @@ contract ReentrantMockPolicy is IPolicy {
         uint256 value,
         bytes calldata data,
         Operation operation,
+        address,
         bytes calldata,
         AccessSelector.T
     ) external override returns (bytes4 magicValue) {

--- a/test/allowedModulePolicy.spec.ts
+++ b/test/allowedModulePolicy.spec.ts
@@ -75,22 +75,22 @@ describe('AllowedModulePolicy', function () {
         ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
       )
 
-      // Create context with module address
-      const context = ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
-
-      // Call checkTransaction and verify it returns the magic value
+      // Call checkTransaction and verify it returns the magic value. The module is passed as its
+      // own argument (the engine supplies it from the guard entry point); `context` is unused.
       const result = await allowedModulePolicy.checkTransaction(
         safeAddress,
         randomAddress(), // to address (doesn't matter for this policy)
         0, // value (doesn't matter for this policy)
         '0x', // data (doesn't matter for this policy)
         SafeOperation.Call,
-        context,
+        moduleAddress,
+        '0x', // context (unused by this policy)
         0 // AccessSelector.T (doesn't matter for this policy)
       )
 
-      // This should match IPolicy.checkTransaction.selector
-      expect(result).to.equal('0x2c5dcbd7')
+      // This should match IPolicy.checkTransaction.selector. Derived rather than hardcoded, since
+      // the magic value is the selector and therefore moves whenever the signature changes.
+      expect(result).to.equal(allowedModulePolicy.interface.getFunction('checkTransaction').selector)
     })
 
     it('Should revert on checkTransaction for non-allowed module', async function () {
@@ -99,12 +99,18 @@ describe('AllowedModulePolicy', function () {
       const safeAddress = await safe.getAddress()
       const randomModuleAddress = randomAddress()
 
-      // Create context with a random non-configured module address
-      const context = ethers.AbiCoder.defaultAbiCoder().encode(['address'], [randomModuleAddress])
-
-      // Call checkTransaction and expect it to revert
+      // Call checkTransaction with a random non-configured module and expect it to revert
       await expect(
-        allowedModulePolicy.checkTransaction(safeAddress, randomAddress(), 0, '0x', SafeOperation.Call, context, 0)
+        allowedModulePolicy.checkTransaction(
+          safeAddress,
+          randomAddress(),
+          0,
+          '0x',
+          SafeOperation.Call,
+          randomModuleAddress,
+          '0x',
+          0
+        )
       ).to.be.revertedWithCustomError(allowedModulePolicy, 'UnauthorizedModule')
     })
   })


### PR DESCRIPTION
Give `IPolicy.checkTransaction` an engine-supplied `module` parameter so a policy can tell a module transaction from an owner transaction.

## Context and Motivation

`context` carried two different things with no discriminator: on the module path the engine passed `abi.encode(module)`, while on the transaction path it is carved out of the Safe `signatures` bytes. The Safe transaction hash does not cover `signatures`, and `checkNSignatures` accepts arbitrary trailing bytes, so *any* executor chooses `context` freely.

`AllowedModulePolicy` read the module from `context`, so appending 32 bytes to the signatures forged a module identity. Demonstrated: with the policy as the CALL fallback, an owner-signed transaction to an unconfigured target is denied, but a non-owner relayer resubmitting the same signatures with `abi.encode(module)` appended executed it. A policy meant to authorize only module traffic became an allow-all for owner traffic, escalated by a party that signed nothing.

## Decisions and Tradeoffs

- Policy *selection* is untouched — one policy list, two fallback keys, no new `AccessSelector` dimension. Only the policy's *input* changes.
- The module is held in `$checkingModule`, set by `_enterCheck` at the guard entry, rather than passed as an argument to the recursive `checkTransaction`. A policy able to pass its own `module` could forge the authorization path it is checked under, which is the property this change exists to provide. As a result `IPolicyEngine.checkTransaction` is unchanged and `MultiSendPolicy` needs no edit: sub-transactions inherit the batch's authorization path.
- On the module path `context` is now empty, so `context` has one meaning everywhere: untrusted, executor-supplied data. Modules lose the ability to pass context, which is not a regression — `abi.encode(module)` was all it carried.
- `AllowedModulePolicy` rejects `module == address(0)`, which is what confines it to the module path. `configure` rejects a zero module too, since a zero entry would be matched by every owner transaction. Both use the already declared but unused `InvalidModule`.
- `module` sits between `operation` and `context` rather than last, grouping the authorization inputs together.
- The magic value moves from `0x2c5dcbd7` to `0xcbd11d55`, since it is defined as `IPolicy.checkTransaction.selector`. The only place that hardcoded it was a test, now deriving it from the interface so it cannot rot again. No other in-repo consumer depends on it.

## Testing

Suite 81 passing (unchanged baseline); build, lint and typecheck green. The two `AllowedModulePolicy` unit tests that passed the module through `context` were updated mechanically. Verified against the reproduction: the forged-context transaction now reverts `AccessDenied(allowedModulePolicy)`. Dedicated regression tests follow in the next PR.