### PR TITLE
test: pin the authenticated module boundary

### DIFF
--- a/test/moduleContext.spec.ts
+++ b/test/moduleContext.spec.ts
@@ -1,0 +1,278 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai'
+import { ZeroAddress, solidityPacked } from 'ethers'
+import { ethers } from 'hardhat'
+
+import {
+  SafeOperation,
+  buildSafeTransaction,
+  createConfiguration,
+  createSafe,
+  encodeMultiSend,
+  execTransaction,
+  randomAddress,
+  safeSignTypedData
+} from '../src/utils'
+import { deployAllowedModulePolicy, deployMultiSendPolicy, deploySafeContracts, deploySafePolicyGuard } from './deploy'
+
+/**
+ * The module authorizing a transaction reaches policies as its own engine-supplied argument, not
+ * through the caller-chosen `context`. These tests pin that boundary: a forged context must not be
+ * mistaken for a module, while genuine module transactions (including MultiSend batches, which are
+ * checked recursively) must still see the real module.
+ */
+describe('Authenticated module parameter', function () {
+  async function fixture() {
+    const [deployer, owner, other] = await ethers.getSigners()
+
+    const { safePolicyGuard } = await deploySafePolicyGuard()
+    const { allowedModulePolicy } = await deployAllowedModulePolicy()
+    const { multiSendPolicy } = await deployMultiSendPolicy()
+    const { safeProxyFactory, safe: safeSingleton, multiSend } = await deploySafeContracts()
+
+    const safe = await createSafe({
+      owner,
+      guard: ZeroAddress,
+      saltNonce: BigInt(0x4d),
+      safeProxyFactory,
+      singleton: safeSingleton
+    })
+
+    const testModule = await (await ethers.getContractFactory('TestModule')).deploy()
+    const moduleAddress = await testModule.getAddress()
+
+    return {
+      deployer,
+      owner,
+      other,
+      safe,
+      safePolicyGuard,
+      allowedModulePolicy,
+      multiSendPolicy,
+      multiSend,
+      testModule,
+      moduleAddress
+    }
+  }
+
+  /**
+   * Configures `AllowedModulePolicy` as the CALL fallback for `safe` (so it is reached by owner
+   * transactions as well as module ones), enables the module, then installs both guards.
+   */
+  async function hardenWithModuleFallback(
+    owner: any,
+    safe: any,
+    safePolicyGuard: any,
+    policyAddress: string,
+    moduleAddress: string
+  ) {
+    const guardAddress = await safePolicyGuard.getAddress()
+    const safeAddress = await safe.getAddress()
+
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: guardAddress,
+      data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+        [
+          createConfiguration({
+            policy: policyAddress,
+            data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
+          })
+        ]
+      ])
+    })
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: safeAddress,
+      data: safe.interface.encodeFunctionData('enableModule', [moduleAddress])
+    })
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: safeAddress,
+      data: safe.interface.encodeFunctionData('setModuleGuard', [guardAddress])
+    })
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: safeAddress,
+      data: safe.interface.encodeFunctionData('setGuard', [guardAddress])
+    })
+  }
+
+  describe('Forged module identity', function () {
+    it('Should deny an owner transaction that appends a module address as context', async function () {
+      const { owner, other, safe, safePolicyGuard, allowedModulePolicy, moduleAddress } = await loadFixture(fixture)
+      await hardenWithModuleFallback(
+        owner,
+        safe,
+        safePolicyGuard,
+        await allowedModulePolicy.getAddress(),
+        moduleAddress
+      )
+
+      const to = randomAddress()
+      const safeTx = buildSafeTransaction({ to, nonce: await safe.nonce() })
+
+      // The owner signs the transaction. The signed hash does not cover the `signatures` bytes, so
+      // it is identical whether or not a context is appended -- which is what makes the context
+      // freely choosable by whoever submits the transaction.
+      const { data: signature } = await safeSignTypedData(owner, await safe.getAddress(), safeTx)
+
+      // `other` is not an owner and signed nothing; it appends a forged "module" context.
+      const forgedContext = ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
+      const signatures = solidityPacked(['bytes', 'bytes', 'uint256'], [signature, forgedContext, 32])
+
+      await expect(
+        safe
+          .connect(other)
+          .execTransaction(to, 0n, '0x', SafeOperation.Call, 0n, 0n, 0n, ZeroAddress, ZeroAddress, signatures)
+      )
+        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+        .withArgs(await allowedModulePolicy.getAddress())
+    })
+
+    it('Should deny an owner transaction with no context', async function () {
+      const { owner, safe, safePolicyGuard, allowedModulePolicy, moduleAddress } = await loadFixture(fixture)
+      await hardenWithModuleFallback(
+        owner,
+        safe,
+        safePolicyGuard,
+        await allowedModulePolicy.getAddress(),
+        moduleAddress
+      )
+
+      // `module` is `address(0)` for an owner transaction, so the policy rejects it. The revert
+      // reason is the policy's own `InvalidModule`, surfaced by the engine as `AccessDenied`.
+      await expect(execTransaction({ owners: [owner], safe, to: randomAddress() }))
+        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+        .withArgs(await allowedModulePolicy.getAddress())
+    })
+  })
+
+  describe('Genuine module transactions', function () {
+    it('Should allow a transaction from the configured module', async function () {
+      const { owner, safe, safePolicyGuard, allowedModulePolicy, testModule, moduleAddress } =
+        await loadFixture(fixture)
+      await hardenWithModuleFallback(
+        owner,
+        safe,
+        safePolicyGuard,
+        await allowedModulePolicy.getAddress(),
+        moduleAddress
+      )
+
+      expect(
+        await testModule.executeTx.staticCall(await safe.getAddress(), randomAddress(), 0, '0x', SafeOperation.Call)
+      ).to.equal(true)
+    })
+
+    it('Should not leak the module into a later owner transaction', async function () {
+      const { owner, safe, safePolicyGuard, allowedModulePolicy, testModule, moduleAddress } =
+        await loadFixture(fixture)
+      await hardenWithModuleFallback(
+        owner,
+        safe,
+        safePolicyGuard,
+        await allowedModulePolicy.getAddress(),
+        moduleAddress
+      )
+
+      // A successful module transaction sets `$checkingModule`; `_exitCheck` must clear it, or the
+      // next owner transaction would be checked as though the module had authorized it.
+      await testModule.executeTx(await safe.getAddress(), randomAddress(), 0, '0x', SafeOperation.Call)
+
+      await expect(execTransaction({ owners: [owner], safe, to: randomAddress() }))
+        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+        .withArgs(await allowedModulePolicy.getAddress())
+    })
+
+    it('Should propagate the module to MultiSend sub-transaction checks', async function () {
+      const {
+        owner,
+        safe,
+        safePolicyGuard,
+        allowedModulePolicy,
+        multiSendPolicy,
+        multiSend,
+        testModule,
+        moduleAddress
+      } = await loadFixture(fixture)
+
+      const guardAddress = await safePolicyGuard.getAddress()
+      const safeAddress = await safe.getAddress()
+      const multiSendAddress = await multiSend.getAddress()
+      const subTarget = randomAddress()
+
+      // MultiSendPolicy for the batch itself, AllowedModulePolicy for the sub-transaction target.
+      // The sub-checks are driven by MultiSendPolicy recursing into the engine, so they only pass
+      // if the module recorded at the guard entry is still what the engine supplies.
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: guardAddress,
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [
+            createConfiguration({
+              target: multiSendAddress,
+              selector: multiSend.interface.getFunction('multiSend')!.selector,
+              operation: SafeOperation.DelegateCall,
+              policy: await multiSendPolicy.getAddress()
+            }),
+            createConfiguration({
+              target: subTarget,
+              policy: await allowedModulePolicy.getAddress(),
+              data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
+            })
+          ]
+        ])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: safeAddress,
+        data: safe.interface.encodeFunctionData('enableModule', [moduleAddress])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: safeAddress,
+        data: safe.interface.encodeFunctionData('setModuleGuard', [guardAddress])
+      })
+
+      const batch = multiSend.interface.encodeFunctionData('multiSend', [
+        encodeMultiSend([{ to: subTarget, value: 0, data: '0x', operation: SafeOperation.Call }])
+      ])
+
+      expect(
+        await testModule.executeTx.staticCall(safeAddress, multiSendAddress, 0, batch, SafeOperation.DelegateCall)
+      ).to.equal(true)
+    })
+  })
+
+  describe('Configuration', function () {
+    it('Should reject configuring the zero address as an allowed module', async function () {
+      const { owner, safe, safePolicyGuard, allowedModulePolicy } = await loadFixture(fixture)
+
+      // A zero entry would be matched by every owner transaction, for which the engine supplies
+      // `module == address(0)`, turning the policy into an allow-all.
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await safePolicyGuard.getAddress(),
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+            [
+              createConfiguration({
+                policy: await allowedModulePolicy.getAddress(),
+                data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [ZeroAddress])
+              })
+            ]
+          ])
+        })
+      ).to.be.revertedWithCustomError(allowedModulePolicy, 'InvalidModule')
+    })
+  })
+})


### PR DESCRIPTION
Regression tests for the engine-supplied `module` parameter: a forged context must not be mistaken for a module, and genuine module transactions must still see the real one.

## Context and Motivation

The previous PR moved the module identity out of the caller-chosen `context` and into engine state. These tests lock that boundary so it cannot regress, and cover the paths the change touches: the transaction path (no module), the module path, and `MultiSendPolicy`'s recursion (which inherits the module from engine state rather than forwarding it).

## Decisions and Tradeoffs

- The forged-context test uses a genuine non-owner submitter: `owner` signs with `safeSignTypedData`, `other` submits with the forged bytes appended. That is the real threat model — a relayer replaying signatures it did not produce — so the call is built manually rather than through `execTransaction`, which hardcodes the first owner as executor.
- It asserts `AccessDenied` *with* the policy address rather than a bare revert, which proves the signature check passed and the policy was actually reached and denied, instead of the transaction failing earlier for an unrelated reason.
- The `any` parameter types on the local `hardenWithModuleFallback` helper follow the existing convention in `test/reentrancy.spec.ts`.

## Testing

Suite 87 passing (81 + 6), build/lint/typecheck green.

Verified the tests can fail: re-run against the pre-fix contracts, 3 of the 6 fail — the forged-context test, the MultiSend propagation test, and the zero module configuration test. The other 3 are controls that should pass either way.

That run also surfaced a latent bug this change repairs. Pre-fix, a module-initiated MultiSend could never satisfy `AllowedModulePolicy` on its sub-transactions: the engine passed `abi.encode(module)` as context, and `MultiSendPolicy._decodeNextContext` reads the leading 32 bytes as a length prefix, so it read the module address as an enormous length and reverted out of bounds. Module identity was silently broken through MultiSend, not just forgeable.