### PR TITLE
feat(guard): reject configureImmediately once the guard is installed

### DIFF
--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.28;
 
 import {PolicyEngine, AccessSelector} from "./core/PolicyEngine.sol";
 import {IERC165} from "./interfaces/IERC165.sol";
+import {ISafe} from "./interfaces/ISafe.sol";
 import {ISafeModuleGuard} from "./interfaces/ISafeModuleGuard.sol";
 import {ISafeTransactionGuard} from "./interfaces/ISafeTransactionGuard.sol";
 import {Operation} from "./interfaces/Operation.sol";
@@ -34,6 +35,18 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
      * @notice The delay for the configuration change and guard removal.
      */
     uint256 public immutable DELAY;
+
+    /**
+     * @dev `keccak256("guard_manager.guard.address")` — Safe's `GuardManager.GUARD_STORAGE_SLOT`.
+     */
+    bytes32 private constant _GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+
+    /**
+     * @dev `keccak256("module_manager.module_guard.address")` — Safe's
+     *      `ModuleManager.MODULE_GUARD_STORAGE_SLOT`.
+     */
+    bytes32 private constant _MODULE_GUARD_STORAGE_SLOT =
+        0xb104e0b93118902c651344349b610029d694cfdec91c589c91ebafbcd0289947;
 
     /**
      * @notice The pending policies root for a Safe.
@@ -74,6 +87,11 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
      * @notice Error indicating the policy root configuration is pending.
      */
     error RootConfigurationPending();
+
+    /**
+     * @notice Error indicating this contract is already installed as a guard on the caller.
+     */
+    error GuardAlreadyEnabled();
 
     /**
      * @notice Emitted when a policy root is configured.
@@ -227,14 +245,49 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
     }
 
     /**
-     * @notice Configures and confirms multiple policies for an address.
+     * @dev Whether this contract is installed on `safe` as either its transaction or module guard.
+     */
+    function _isGuardEnabled(address safe) internal view returns (bool) {
+        return
+            _readGuardSlot(safe, _GUARD_STORAGE_SLOT) == address(this) ||
+            _readGuardSlot(safe, _MODULE_GUARD_STORAGE_SLOT) == address(this);
+    }
+
+    /**
+     * @dev Reads a guard address out of `safe`'s storage. Returns `address(0)` when `safe` does not
+     *      answer `getStorageAt` as a Safe would, so that non-Safe callers keep working rather than
+     *      reverting on a failed decode.
+     */
+    function _readGuardSlot(address safe, bytes32 slot) private view returns (address guard) {
+        (bool success, bytes memory returnData) = safe.staticcall(
+            abi.encodeCall(ISafe.getStorageAt, (uint256(slot), 1))
+        );
+
+        // A Safe answers with `bytes` holding a single word, ABI-encoded as
+        // 32 offset + 32 length + 32 data.
+        if (!success || returnData.length < 96) {
+            return address(0);
+        }
+
+        // Read the data word directly rather than via `abi.decode`, which would revert on a caller
+        // that answers with a malformed encoding instead of leaving it to the length check above.
+        // solhint-disable-next-line no-inline-assembly
+        assembly ("memory-safe") {
+            guard := and(mload(add(returnData, 0x60)), 0xffffffffffffffffffffffffffffffffffffffff)
+        }
+    }
+
+    /**
+     * @notice Configures and confirms multiple policies for an address, bypassing the delay.
      * @param configurations The array of configurations to be applied.
-     * @dev This does not have to check if the guard is enabled, as if the guard is set,
-     *      then this tx will fail in `checkTransaction`.
-     *      This is a convenience function to avoid having to call `configurePolicy` and then
-     *      `confirmPolicy` separately with a delay.
+     * @dev Only usable before this contract is installed as a guard, which is what keeps the delay
+     *      unavoidable afterwards. Relying on the guard check to reject the call is not sufficient:
+     *      any policy permitting a `CALL` to this contract (a permissive fallback, for example)
+     *      would let it through and defeat the timelock, including for guard removal.
      */
     function configureImmediately(Configuration[] calldata configurations) external virtual {
+        require(!_isGuardEnabled(msg.sender), GuardAlreadyEnabled());
+
         for (uint256 i = 0; i < configurations.length; i++) {
             _confirmPolicy(
                 msg.sender,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -4,3 +4,6 @@ export const SEVEN_DAYS_IN_SECONDS = 7n * ONE_DAY_IN_SECONDS
 
 // Guard Storage Slot
 export const GUARD_STORAGE_SLOT = '0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8'
+
+// Module Guard Storage Slot
+export const MODULE_GUARD_STORAGE_SLOT = '0xb104e0b93118902c651344349b610029d694cfdec91c589c91ebafbcd0289947'

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -12,7 +12,7 @@ import {
   randomSelector,
   SafeOperation
 } from '../src/utils'
-import { deploySafePolicyGuard, deploySafeContracts, deployMockPolicy } from './deploy'
+import { deployAllowPolicy, deploySafePolicyGuard, deploySafeContracts, deployMockPolicy } from './deploy'
 
 describe('SafePolicyGuard', function () {
   async function fixture() {
@@ -280,6 +280,111 @@ describe('SafePolicyGuard', function () {
       )
         .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
         .withArgs(ZeroAddress)
+    })
+
+    it('Should not be able to configure immediately even when a policy permits calling the guard', async function () {
+      // The guard check is not enough on its own to keep `configureImmediately` unreachable: a
+      // permissive fallback lets the call through, which would defeat the delay entirely.
+      const { owner, safePolicyGuard, safe, mockPolicy } = await loadFixture(fixture)
+      const guardAddress = await safePolicyGuard.getAddress()
+
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: guardAddress,
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [createConfiguration({ policy: await mockPolicy.getAddress() })]
+        ])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [guardAddress])
+      })
+
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: guardAddress,
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+            [createConfiguration({ target: randomAddress(), policy: await mockPolicy.getAddress() })]
+          ])
+        })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'GuardAlreadyEnabled')
+    })
+
+    it('Should not be able to configure immediately when only the module guard is enabled', async function () {
+      const { owner, safePolicyGuard, safe, mockPolicy } = await loadFixture(fixture)
+      const guardAddress = await safePolicyGuard.getAddress()
+
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setModuleGuard', [guardAddress])
+      })
+
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: guardAddress,
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+            [createConfiguration({ policy: await mockPolicy.getAddress() })]
+          ])
+        })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'GuardAlreadyEnabled')
+    })
+
+    it('Should be able to configure immediately again after the guard is removed', async function () {
+      // The documented re-bootstrap flow: once the guard is off, the pre-guard path is available
+      // again to clean up the policy that allowed its removal.
+      const { owner, safePolicyGuard, safe, mockPolicy } = await loadFixture(fixture)
+      const guardAddress = await safePolicyGuard.getAddress()
+      const { allowPolicy } = await deployAllowPolicy()
+
+      // Allow `setGuard` so the guard can be removed, then enable the guard.
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: guardAddress,
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [
+            createConfiguration({
+              target: await safe.getAddress(),
+              selector: safe.interface.getFunction('setGuard')?.selector,
+              policy: await allowPolicy.getAddress()
+            })
+          ]
+        ])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [guardAddress])
+      })
+
+      // Remove the guard, which the AllowPolicy above permits.
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [ZeroAddress])
+      })
+
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: guardAddress,
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+            [createConfiguration({ target: randomAddress(), policy: await mockPolicy.getAddress() })]
+          ])
+        })
+      ).to.not.be.reverted
     })
   })
 


### PR DESCRIPTION
Make `configureImmediately` check the Safe's guard slots instead of relying on the policy check to reject it, so the configuration delay is unavoidable once the guard is live.

## Context and Motivation

`configureImmediately` had no guard-enabled check. Its NatSpec claimed the call would fail in `checkTransaction` if the guard were set, any policy that authorizes such a call breaks it — a permissive fallback being the easiest way to get there, and the README already advertises fallback policies as a supported shape. The call then goes through, and a Safe can rewrite every policy and remove the guard with no delay at all. Demonstrated with `DELAY` at 7 days: install an `AllowPolicy` on `setGuard` via `configureImmediately` with the guard live, then `setGuard(0)`. No pending root was ever created.

The delay is the engine's only protection against a compromised owner set, so it should not be opt-out by accident.

## Decisions and Tradeoffs

- Reads the Safe's two guard storage slots rather than latching "this Safe has been checked once". A latch is grief-able — anyone can call the 11-arg `checkTransaction` directly, so a Safe tricked into calling the guard entry before installing the guard would be locked out of the bootstrap path forever — and it would permanently break the re-bootstrap flow documented at README:103, since it never clears when the guard is removed.
- Both slots are checked, so installing only the module guard also blocks. Only `address(this)` blocks; a different guard being installed is irrelevant here.
- Reads the returned word with `assembly ("memory-safe")` and a 160-bit mask rather than `abi.decode`. `getStorageAt` returns `bytes`, so decoding as `bytes32` would read the ABI offset word, and decoding as `bytes` reverts on a malformed encoding — which would put a revert back on the bootstrap path for a caller that answers oddly. The length check stays the only gate. The mask matters because an arbitrary caller can return dirty high bits.
- Non-Safe callers keep working: a staticcall to an EOA succeeds with empty return data, which the length check turns into `address(0)`.
- Couples to Safe's storage layout. Both constants are verified against Safe 1.5.0 (`GuardManager.sol:66`, `ModuleManager.sol:65`) and by keccak of their preimages, and `MODULE_GUARD_STORAGE_SLOT` is added to `lib/constants.ts`.

## Testing

Suite 90 passing (87 + 3), build/lint/typecheck green. Verified against the reproduction: the zero-delay guard removal now reverts `GuardAlreadyEnabled`.

New tests cover a permissive fallback no longer opening the door, the module-guard-only case, and that `configureImmediately` works again after the guard is removed. The pre-existing "cannot configure immediately if the guard is enabled" test still passes with `AccessDenied`, since the guard check fires before the function body.