### PR TITLE
feat(guard): revert when a guarded execution fails

### DIFF
--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -94,6 +94,16 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
     error GuardAlreadyEnabled();
 
     /**
+     * @notice Error indicating the guarded transaction failed to execute.
+     */
+    error ExecutionFailed();
+
+    /**
+     * @notice Error indicating the guarded module transaction failed to execute.
+     */
+    error ModuleExecutionFailed();
+
+    /**
      * @notice Emitted when a policy root is configured.
      * @param safe The address of the Safe.
      * @param root The root is a hash of the policy configurations.
@@ -186,12 +196,16 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         _exitCheck();
     }
 
-    /* solhint-disable no-empty-blocks */
     /**
      * @inheritdoc ISafeTransactionGuard
+     * @dev The hook still runs on a successful transaction; what it cannot observe while
+     *      `safeTxGas == 0` and `gasPrice == 0` are enforced is a *failure*, because the Safe
+     *      reverts before calling it. Kept so atomicity is enforced locally rather than assumed of
+     *      the Safe version in use.
      */
-    function checkAfterExecution(bytes32 hash, bool success) external override {}
-    /* solhint-enable no-empty-blocks */
+    function checkAfterExecution(bytes32, bool success) external pure override {
+        require(success, ExecutionFailed());
+    }
 
     /**
      * @inheritdoc ISafeModuleGuard
@@ -211,12 +225,16 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
         return bytes32(0);
     }
 
-    /* solhint-disable no-empty-blocks */
     /**
      * @inheritdoc ISafeModuleGuard
+     * @dev Checks are pre-execution only, so any state a policy wrote during the check commits with
+     *      the transaction. The module path has no `safeTxGas` equivalent —
+     *      `execTransactionFromModule` returns `false` instead of reverting — so without this a
+     *      policy's writes would commit against an action that never took effect.
      */
-    function checkAfterModuleExecution(bytes32 txHash, bool success) external override {}
-    /* solhint-enable no-empty-blocks */
+    function checkAfterModuleExecution(bytes32, bool success) external pure override {
+        require(success, ModuleExecutionFailed());
+    }
 
     /**
      * @dev Decodes additional context to pass to the policy from the signatures bytes.

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -14,6 +14,14 @@ import {
 } from '../src/utils'
 import { deployAllowPolicy, deploySafePolicyGuard, deploySafeContracts, deployMockPolicy } from './deploy'
 
+// Mirrors ReentrantMockPolicy.Mode.
+enum ReentrantMockPolicyMode {
+  None,
+  ReenterGuardEntry,
+  ReenterEngine,
+  WriteState
+}
+
 describe('SafePolicyGuard', function () {
   async function fixture() {
     const [, owner, other] = await ethers.getSigners()
@@ -985,6 +993,103 @@ describe('SafePolicyGuard', function () {
       await expect(testModule.executeTx(await safe.getAddress(), randomAddress(), 0, '0x', SafeOperation.Call))
         .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
         .withArgs(ZeroAddress)
+    })
+  })
+
+  describe('Execution outcome', function () {
+    // Checks run pre-execution only, so a policy's writes commit with the transaction. These pin
+    // that a failed execution still rolls them back on both authorization paths.
+    async function statefulFixture() {
+      const base = await loadFixture(fixture)
+      const { owner, safe, safePolicyGuard } = base
+
+      const statefulPolicy = await (await ethers.getContractFactory('ReentrantMockPolicy')).deploy()
+      await statefulPolicy.setMode(ReentrantMockPolicyMode.WriteState)
+
+      const testModule = await (await ethers.getContractFactory('TestModule')).deploy()
+      const guardAddress = await safePolicyGuard.getAddress()
+      const safeAddress = await safe.getAddress()
+
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: guardAddress,
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [createConfiguration({ policy: await statefulPolicy.getAddress() })]
+        ])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: safeAddress,
+        data: safe.interface.encodeFunctionData('enableModule', [await testModule.getAddress()])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: safeAddress,
+        data: safe.interface.encodeFunctionData('setModuleGuard', [guardAddress])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: safeAddress,
+        data: safe.interface.encodeFunctionData('setGuard', [guardAddress])
+      })
+
+      // A contract with neither `receive` nor a matching function reverts on a 0-value empty call.
+      const revertingTarget = await statefulPolicy.getAddress()
+
+      return { ...base, statefulPolicy, testModule, revertingTarget }
+    }
+
+    it('Should revert a module transaction whose execution failed', async function () {
+      const { safe, safePolicyGuard, statefulPolicy, testModule, revertingTarget } = await statefulFixture()
+
+      expect(await statefulPolicy.writes()).to.equal(0n)
+
+      // `execTransactionFromModule` returns `false` rather than reverting, so without the
+      // after-execution check the policy's write would commit against an action that never happened.
+      await expect(
+        testModule.executeTx(await safe.getAddress(), revertingTarget, 0, '0x', SafeOperation.Call)
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'ModuleExecutionFailed')
+
+      expect(await statefulPolicy.writes()).to.equal(0n)
+    })
+
+    it('Should keep a successful module transaction working', async function () {
+      const { safe, statefulPolicy, testModule } = await statefulFixture()
+
+      await testModule.executeTx(await safe.getAddress(), randomAddress(), 0, '0x', SafeOperation.Call)
+
+      expect(await statefulPolicy.writes()).to.equal(1n)
+    })
+
+    it('Should revert a transaction whose execution failed', async function () {
+      const { owner, safe, statefulPolicy, revertingTarget } = await statefulFixture()
+
+      // The Safe already reverts this itself given `safeTxGas == 0` and `gasPrice == 0`; asserted
+      // here as the transaction-path counterpart of the module case above.
+      expect(await statefulPolicy.writes()).to.equal(0n)
+      await expect(execTransaction({ owners: [owner], safe, to: revertingTarget })).to.be.reverted
+      expect(await statefulPolicy.writes()).to.equal(0n)
+    })
+
+    it('Should reject the after-execution hooks reporting failure', async function () {
+      const { safePolicyGuard } = await loadFixture(fixture)
+
+      await expect(safePolicyGuard.checkAfterExecution(ethers.ZeroHash, false)).to.be.revertedWithCustomError(
+        safePolicyGuard,
+        'ExecutionFailed'
+      )
+      await expect(safePolicyGuard.checkAfterModuleExecution(ethers.ZeroHash, false)).to.be.revertedWithCustomError(
+        safePolicyGuard,
+        'ModuleExecutionFailed'
+      )
+
+      // Success is a no-op, so the hooks stay callable without any bookkeeping.
+      await expect(safePolicyGuard.checkAfterExecution(ethers.ZeroHash, true)).to.not.be.reverted
+      await expect(safePolicyGuard.checkAfterModuleExecution(ethers.ZeroHash, true)).to.not.be.reverted
     })
   })
 })


### PR DESCRIPTION
Implement the after-execution hooks so a failed execution rolls back the state a policy wrote during its pre-check.

## Context and Motivation

Checks are pre-execution only, so anything a stateful policy writes during `checkTransaction` commits with the transaction. On the transaction path that stays consistent because the Safe reverts a failed execution when `safeTxGas` and `gasPrice` are both zero, which the guard already enforces.

The module path has no such lever: `execTransactionFromModule` returns `false` and the outer transaction commits. So a policy's writes committed against an action that never took effect. Demonstrated: with a stateful policy as the CALL fallback, a module transaction to a reverting target returned status 1, emitted `ExecutionFromModuleFailure`, and still incremented the policy's counter. The practical consequence is free, repeatable griefing of any policy budget — an attacker who can trigger a module exhausts a rate limit with calls engineered to fail, moving no funds.

This also corrects the epic's predecessor, which recorded the gap as an accepted residual risk rather than fixing it.

## Decisions and Tradeoffs

- `checkAfterModuleExecution` reverting on failure is the only way to restore atomicity on the module path, since there is no `safeTxGas` to force. The alternative — restricting stateful policies to the transaction path — would need the authorization-path discriminator to be load-bearing for correctness rather than just for identity.
- `checkAfterExecution` gets the same check. The hook still runs on a successful transaction; what it cannot observe while `safeTxGas == 0` and `gasPrice == 0` are enforced is a *failure*, because the Safe reverts before calling it. It
converts a cross-contract assumption about the Safe version into a locally enforced invariant, which is precisely what would have prevented the module-path gap.
- Neither hook needs a reentrancy gate: they hold no state, so an external caller passing `false` only reverts its own frame.
- Behavioural change: a module that deliberately tolerates a failing inner call will now revert. That is intended.

## Testing

Suite 94 passing (90 + 4), build/lint/typecheck green. Verified against the reproduction: the failing module transaction now reverts `ModuleExecutionFailed`.

New tests assert the policy counter is unchanged before *and* after a failed module transaction, so they prove the rollback rather than just the revert; that a successful module transaction still commits its write; the transaction-path counterpart, so both paths are visibly symmetric; and the hooks themselves, documenting that being externally callable is harmless.