### PR TITLE
feat(guard): carry policy context in a typed signature extension

### DIFF
--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -7,6 +7,7 @@ import {ISafe} from "./interfaces/ISafe.sol";
 import {ISafeModuleGuard} from "./interfaces/ISafeModuleGuard.sol";
 import {ISafeTransactionGuard} from "./interfaces/ISafeTransactionGuard.sol";
 import {Operation} from "./interfaces/Operation.sol";
+import {SignatureExtension} from "./libraries/SignatureExtension.sol";
 
 /**
  * @title Safe Policy Guard
@@ -47,6 +48,12 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
      */
     bytes32 private constant _MODULE_GUARD_STORAGE_SLOT =
         0xb104e0b93118902c651344349b610029d694cfdec91c589c91ebafbcd0289947;
+
+    /**
+     * @dev `keccak256("SafePolicyGuard.PolicyContext.v1")` — the {SignatureExtension} type carrying
+     *      policy context in the Safe `signatures` tail.
+     */
+    bytes32 private constant _CONTEXT_TYPE_HASH = 0x5aa463b48748f9162d63ae93151d31fed6a96b34cd2ae84ef33d25b0bdea62e4;
 
     /**
      * @notice The pending policies root for a Safe.
@@ -238,24 +245,16 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
 
     /**
      * @dev Decodes additional context to pass to the policy from the signatures bytes.
+     *      Absence is not an error, so signatures carrying no context (plain ECDSA owner signatures)
+     *      work for policies that do not need any. A blob that claims the type but is malformed does
+     *      revert, which denies the transaction rather than silently yielding empty context.
      */
     function _decodeContext(bytes calldata signatures) internal pure returns (bytes calldata) {
-        // We intentionally don't fail when the signatures are too short to decode the context. This
-        // is so that signatures for normal transactions without any additional context (i.e. with
-        // ECDSA signatures from the owners) works for policies that don't require any additional
-        // context without needing to append `uint256(0)` to the signatures bytes.
-
-        if (signatures.length < 66) {
+        if (!SignatureExtension.has(signatures, _CONTEXT_TYPE_HASH)) {
             return _emptyContext();
         }
 
-        uint256 end = signatures.length - 32;
-        uint256 length = uint256(bytes32(signatures[end:]));
-        if (length > end) {
-            return _emptyContext();
-        }
-
-        return signatures[end - length:end];
+        return SignatureExtension.payload(signatures, _CONTEXT_TYPE_HASH);
     }
 
     function _emptyContext() internal pure returns (bytes calldata) {

--- a/contracts/libraries/SignatureExtension.sol
+++ b/contracts/libraries/SignatureExtension.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.28;
+
+/**
+ * @title SignatureExtension
+ * @notice A reusable format for appending typed, variable-length data after a Safe's owner signatures.
+ * @dev Vendored from `safe-research/safenet` at commit
+ *      `1b3c9422600a03d69c4048a160d39b0e32401f28`, path
+ *      `contracts/src/libraries/SignatureExtension.sol`. Only the pragma differs, relaxed from
+ *      `^0.8.30` so it compiles with this package's pinned `0.8.28`. Keep the two in sync.
+ *
+ *      A *signature extension* is a self-describing envelope appended to Safe's `signatures` bytes.
+ *      Safe's own signature parser reads owner signatures front-to-back and ignores trailing bytes, so a
+ *      consumer (e.g. a transaction guard) can carry extra authorisation data in the tail and recover it
+ *      here without disturbing Safe's parse.
+ *
+ *      Envelope layout:
+ *
+ *          [safe owner signatures] [payload: N bytes] [uint256 payloadLength = N] [bytes32 typeHash]
+ *
+ *      - The **type hash** is the terminal 32-byte word. It both identifies the extension type and pins
+ *        its version, by the registry convention `typeHash = keccak256("<Owner>.<Name>.v<N>")` (e.g.
+ *        `SafenetGuard.AttestationTrailer.v1`). Anchoring the discriminator at the end makes detection
+ *        independent of any owner-signature suffix, and a consumer of a different type simply does not
+ *        recognise it. A future, post-release format change bumps to a new type hash, which older
+ *        consumers read as "no extension".
+ *      - The **length word** precedes the type hash and gives the payload size, so the payload may be any
+ *        length and is sliceable from the tail in O(1). Total envelope overhead is a fixed 64 bytes.
+ *      - The owner-signature/payload boundary is not exposed: the guard does not need it (Safe parses the
+ *        front independently), and a consumer that does can derive it as
+ *        `signatures.length - payloadLength - {ENVELOPE_OVERHEAD}`.
+ *
+ *      This library is the transport only — payload-agnostic. A typed consumer holds its own `typeHash`
+ *      and decodes the returned payload bytes into its own schema. At most one extension per blob;
+ *      nesting is not supported (a future need would be a new format/version).
+ */
+library SignatureExtension {
+    /**
+     * @dev Fixed envelope overhead: the `uint256 payloadLength` word (32 bytes) plus the terminal
+     *      `bytes32 typeHash` word (32 bytes).
+     */
+    uint256 private constant _ENVELOPE_OVERHEAD = 64;
+
+    /**
+     * @notice Thrown when a blob carries the expected type hash but is not a well-formed envelope — too
+     *         short to hold `[payloadLength][typeHash]`, or a payload length that runs past the front.
+     */
+    error MalformedSignatureExtension();
+
+    /**
+     * @notice Returns whether `signatures` carries an extension of type `typeHash` (ends with it).
+     * @dev Non-reverting recognition: a blob shorter than a word, or not ending in `typeHash`, is simply
+     *      "no extension of this type", so the consumer can fall through to other authorisation paths.
+     *      This is detection only; {payload} performs the full well-formedness validation.
+     * @param signatures The Safe `signatures` blob, optionally suffixed with an extension.
+     * @param typeHash The extension type to look for.
+     * @return present True if the blob ends with `typeHash`.
+     */
+    function has(bytes calldata signatures, bytes32 typeHash) internal pure returns (bool present) {
+        return signatures.length >= 32 && bytes32(signatures[signatures.length - 32:]) == typeHash;
+    }
+
+    /**
+     * @notice Extracts the payload of a `typeHash` extension from `signatures`.
+     * @dev Self-verifying, so it is safe to call standalone without a preceding {has}: reverts
+     *      `MalformedSignatureExtension` if the blob is too short to hold `[payloadLength][typeHash]`, if
+     *      the terminal word is not `typeHash`, or if the encoded payload length runs past the front of
+     *      the blob. The returned slice is a `calldata` view (no copy).
+     * @param signatures The Safe `signatures` blob ending in a `typeHash` extension.
+     * @param typeHash The expected extension type; the terminal word must equal it.
+     * @return payloadData The extension payload (`payloadLength` bytes preceding the length word).
+     */
+    function payload(bytes calldata signatures, bytes32 typeHash) internal pure returns (bytes calldata payloadData) {
+        require(
+            signatures.length >= _ENVELOPE_OVERHEAD && bytes32(signatures[signatures.length - 32:]) == typeHash,
+            MalformedSignatureExtension()
+        );
+        uint256 end = signatures.length - _ENVELOPE_OVERHEAD; // index just past the payload
+        uint256 payloadLength = uint256(bytes32(signatures[end:end + 32]));
+        require(payloadLength <= end, MalformedSignatureExtension());
+        return signatures[end - payloadLength:end];
+    }
+}

--- a/contracts/test/ContextRecorderPolicy.sol
+++ b/contracts/test/ContextRecorderPolicy.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.28;
+
+import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
+import {AccessSelector} from "../libraries/AccessSelector.sol";
+
+/**
+ * @title Context Recorder Policy
+ * @dev Test-only policy that records the `context` the engine passed it and always allows. Lets a
+ *      test assert what the guard decoded, rather than inferring it from another policy's verdict.
+ */
+contract ContextRecorderPolicy is IPolicy {
+    bytes public lastContext;
+
+    /**
+     * @inheritdoc IPolicy
+     */
+    function checkTransaction(
+        address,
+        address,
+        uint256,
+        bytes calldata,
+        Operation,
+        address,
+        bytes calldata context,
+        AccessSelector.T
+    ) external override returns (bytes4 magicValue) {
+        lastContext = context;
+        return IPolicy.checkTransaction.selector;
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     */
+    function configure(address, AccessSelector.T, bytes memory) external pure override returns (bool) {
+        return true;
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,6 +90,28 @@ export const EIP712_SAFE_TX_TYPE = {
 }
 
 /**
+ * The `SignatureExtension` type hash carrying policy context, mirroring
+ * `SafePolicyGuard._CONTEXT_TYPE_HASH`.
+ */
+export const POLICY_CONTEXT_TYPE_HASH = ethers.id('SafePolicyGuard.PolicyContext.v1')
+
+/**
+ * Appends a `SignatureExtension` envelope carrying `payload` to a Safe `signatures` blob.
+ * @param signatures The owner signatures.
+ * @param payload The policy context to carry in the tail.
+ * @returns The signatures with `[payload][uint256 payloadLength][bytes32 typeHash]` appended.
+ * @dev Safe ignores trailing bytes when parsing owner signatures, so the envelope rides along
+ *      without disturbing verification. The type hash is the terminal word so that the guard can
+ *      recognise the envelope without mistaking unrelated signature data for it.
+ */
+export function appendSignatureExtension(signatures: BytesLike, payload: BytesLike): string {
+  return solidityPacked(
+    ['bytes', 'bytes', 'uint256', 'bytes32'],
+    [signatures, payload, ethers.dataLength(payload), POLICY_CONTEXT_TYPE_HASH]
+  )
+}
+
+/**
  * Function to calculate the address of a proxy contract.
  * @param factory The SafeProxyFactory contract.
  * @param singletonAddress The address of the singleton contract.
@@ -206,7 +228,7 @@ export async function createSafe({
  * @param owner The owner of the Safe.
  * @returns The pre-approved signature.
  */
-async function preApprovedSignature(owner: AddressLike): Promise<string> {
+export async function preApprovedSignature(owner: AddressLike): Promise<string> {
   const ownerAddress = await ethers.resolveAddress(owner)
   return ethers.solidityPacked(['uint256', 'uint256', 'uint8'], [ownerAddress, 0, 1])
 }
@@ -324,11 +346,8 @@ export async function execTransaction({
     throw new Error('signing method not supported')
   }
 
-  if (additionalData.length > 2) {
-    signatureBytes = solidityPacked(
-      ['bytes', 'bytes', 'uint256'],
-      [signatureBytes, additionalData, (additionalData.length - 2) / 2]
-    ) as BytesLike
+  if (ethers.dataLength(additionalData) > 0) {
+    signatureBytes = appendSignatureExtension(signatureBytes, additionalData) as BytesLike
   }
 
   return await safe

--- a/test/moduleContext.spec.ts
+++ b/test/moduleContext.spec.ts
@@ -1,10 +1,11 @@
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import { expect } from 'chai'
-import { ZeroAddress, solidityPacked } from 'ethers'
+import { ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
 import {
   SafeOperation,
+  appendSignatureExtension,
   buildSafeTransaction,
   createConfiguration,
   createSafe,
@@ -121,9 +122,11 @@ describe('Authenticated module parameter', function () {
       // freely choosable by whoever submits the transaction.
       const { data: signature } = await safeSignTypedData(owner, await safe.getAddress(), safeTx)
 
-      // `other` is not an owner and signed nothing; it appends a forged "module" context.
+      // `other` is not an owner and signed nothing; it appends a well-formed context envelope
+      // carrying a forged "module". The envelope is valid, so the guard does decode and pass it to
+      // the policy -- the denial must come from the policy reading `module`, not from the decode.
       const forgedContext = ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
-      const signatures = solidityPacked(['bytes', 'bytes', 'uint256'], [signature, forgedContext, 32])
+      const signatures = appendSignatureExtension(signature, forgedContext)
 
       await expect(
         safe

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -8,6 +8,8 @@ import {
   createSafe,
   execTransaction,
   getConfigurationRoot,
+  POLICY_CONTEXT_TYPE_HASH,
+  preApprovedSignature,
   randomAddress,
   randomSelector,
   SafeOperation
@@ -993,6 +995,81 @@ describe('SafePolicyGuard', function () {
       await expect(testModule.executeTx(await safe.getAddress(), randomAddress(), 0, '0x', SafeOperation.Call))
         .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
         .withArgs(ZeroAddress)
+    })
+  })
+
+  describe('Context decoding', function () {
+    // Context rides in the Safe `signatures` tail as a `SignatureExtension` envelope:
+    // [payload][uint256 payloadLength][bytes32 typeHash]. The terminal type hash is what keeps
+    // unrelated signature data -- an EIP-1271 contract signature, say -- from being read as context.
+    //
+    // These assert on the context the guard actually handed the policy, rather than on a downstream
+    // policy's verdict, because two different decodings can produce the same verdict.
+    async function contextFixture() {
+      const base = await loadFixture(fixture)
+      const { owner, safe, safePolicyGuard } = base
+
+      const recorder = await (await ethers.getContractFactory('ContextRecorderPolicy')).deploy()
+      const target = randomAddress()
+
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [createConfiguration({ target, policy: await recorder.getAddress() })]
+        ])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      return { ...base, recorder, target }
+    }
+
+    it('Should treat signatures not ending in the type hash as carrying no context', async function () {
+      const { owner, safe, recorder, target } = await contextFixture()
+
+      // A raw 32-byte tail appended with NO envelope -- structurally what an EIP-1271 contract
+      // signature's trailing data looks like. The value is deliberately small enough to be a
+      // plausible length: the previous format read this final word as one and would have sliced 32
+      // bytes of the signature out as context.
+      const signatures = ethers.solidityPacked(['bytes', 'uint256'], [await preApprovedSignature(owner), 32n])
+
+      await safe
+        .connect(owner)
+        .execTransaction(target, 0n, '0x', SafeOperation.Call, 0n, 0n, 0n, ZeroAddress, ZeroAddress, signatures)
+
+      expect(await recorder.lastContext()).to.equal('0x')
+    })
+
+    it('Should decode the payload of a well-formed envelope', async function () {
+      const { owner, safe, recorder, target } = await contextFixture()
+      const payload = ethers.id('some policy context')
+
+      await execTransaction({ owners: [owner], safe, to: target, additionalData: payload })
+
+      expect(await recorder.lastContext()).to.equal(payload)
+    })
+
+    it('Should revert on a malformed envelope claiming the type hash', async function () {
+      const { owner, safe, safePolicyGuard, target } = await contextFixture()
+
+      // Terminal word is the type hash, but the declared payload length runs past the front of the
+      // blob. Claiming the type and then being malformed is an error, not "no context".
+      const signatures = ethers.solidityPacked(
+        ['bytes', 'uint256', 'bytes32'],
+        [await preApprovedSignature(owner), ethers.MaxUint256, POLICY_CONTEXT_TYPE_HASH]
+      )
+
+      await expect(
+        safe
+          .connect(owner)
+          .execTransaction(target, 0n, '0x', SafeOperation.Call, 0n, 0n, 0n, ZeroAddress, ZeroAddress, signatures)
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'MalformedSignatureExtension')
     })
   })
 


### PR DESCRIPTION
Replace the ad-hoc context envelope in the Safe `signatures` tail with the `SignatureExtension` format, whose terminal word is a type hash rather than a length.

## Context and Motivation

`_decodeContext` read the final 32 bytes of `signatures` as a payload length. That is exactly where Safe puts EIP-1271 contract-signature data — the contract signature pointer must sit past the static part — so an honest contract signature's tail could be read as a length, and `length <= end` can plausibly hold. A Safe with a smart-contract owner therefore could not reliably pass context: it either resolved to empty or to a garbage slice of the signature.

Anchoring a type hash in the terminal word instead drops accidental collision to ~2^-256, and makes the format typed and versioned so a later change is non-breaking (older consumers read a new type hash as "no extension").

Note this does not make `context` trustworthy — any executor can still build a well-formed envelope with any payload. It makes it unambiguous. Authentication of the authorization path is the `module` parameter's job.

## Decisions and Tradeoffs

- Vendored rather than consumed as a dependency. safenet is `private: true` with no `files`/`exports`, so it is not published; and its `^0.8.30` pragma cannot compile alongside this package's pinned `0.8.28` (verified: Hardhat HH606, since an imported file shares its importer's compilation unit). The header pins the exact upstream commit and records that the pragma is the only difference, so re-syncing is a mechanical diff. Follow-ups track publishing it and bumping solc.
- Absence of an extension stays non-reverting, so plain ECDSA signatures need no padding — the property the previous `< 66` short-circuit provided. But a blob that *claims* the type and is then malformed now reverts, denying the transaction rather than silently yielding empty context.
- `appendSignatureExtension` in `src/utils.ts` is the single place the wire format is built, so `execTransaction`'s `additionalData` and every test moved with one call-site change.
- The decoder tests assert on the context the guard actually handed the policy, via a new `ContextRecorderPolicy`, rather than on a downstream policy's verdict. An empty context and a 32-byte garbage context both make `CoSignerPolicy` fail identically, so a verdict-based assertion cannot tell the two decodings apart.
- `preApprovedSignature` is exported from `src/utils.ts` so a test can assemble a `signatures` blob by hand. `additionalData` always wraps its payload in a well-formed envelope, so it cannot produce the no-envelope case at all.
- The emptiness check on `additionalData` uses `ethers.dataLength(...) > 0` instead of `.length > 2`, which only holds for hex strings and misbehaves for other `BytesLike` values such as `Uint8Array`.

## Testing

Suite 97 passing (94 + 3), build/lint/typecheck green, no compiler warnings.

The forged-context test from the previous PR was updated to build the new envelope. Left alone it kept passing while silently measuring the wrong thing: the old blob no longer ends in the type hash, so it was rejected as "no extension" rather than as a forged module. It now forges a well-formed envelope, so the guard genuinely decodes it and the denial has to come from the policy reading `module`.

Three tests cover the decoder: a raw 32-byte tail with no envelope decodes to an empty context — the value is deliberately small enough to be a plausible length, so the previous format would have sliced 32 bytes of the signature out as context; a well-formed envelope decodes to its payload; and an envelope claiming the type hash with an out-of-range length reverts `MalformedSignatureExtension`.

All three were verified to fail against the restored old decoder. An earlier attempt used a keccak-hash tail, which the old decoder also rejected as an implausible length — so it passed either way and discriminated nothing.
