### PR TITLE
feat(engine): forward policy revert reasons

### DIFF
--- a/contracts/core/PolicyEngine.sol
+++ b/contracts/core/PolicyEngine.sol
@@ -73,6 +73,15 @@ abstract contract PolicyEngine is IPolicyEngine {
     error AccessDenied(address policy);
 
     /**
+     * @notice Error indicating a policy reverted while checking a transaction.
+     * @param policy The address of the policy that reverted.
+     * @param reason The policy's own revert data, forwarded for diagnostics.
+     * @dev Distinct from {AccessDenied}, which covers no policy being configured and a policy
+     *      returning the wrong magic value.
+     */
+    error PolicyReverted(address policy, bytes reason);
+
+    /**
      * @notice Error indicating the policy configuration failed.
      */
     error PolicyConfigurationFailed();
@@ -178,8 +187,8 @@ abstract contract PolicyEngine is IPolicyEngine {
             IPolicy(policy).checkTransaction(safe, to, value, data, operation, $checkingModule, context, access)
         returns (bytes4 magicValue) {
             require(magicValue == IPolicy.checkTransaction.selector, AccessDenied(policy));
-        } catch {
-            revert AccessDenied(policy);
+        } catch (bytes memory reason) {
+            revert PolicyReverted(policy, reason);
         }
         return policy;
     }

--- a/contracts/test/MockPolicy.sol
+++ b/contracts/test/MockPolicy.sol
@@ -13,6 +13,14 @@ contract MockPolicy is IPolicy {
 
     bool public revertConfigure;
 
+    bool public revertCheckWithReason;
+
+    /**
+     * @notice Error carrying a payload, so tests can assert the engine forwards a policy's own
+     *         revert data rather than replacing it.
+     */
+    error MockDenied(uint256 code);
+
     /**
      * @notice This function is used to set the revertTransaction flag.
      * @param revert_ The value to set the revertTransaction flag to.
@@ -32,6 +40,14 @@ contract MockPolicy is IPolicy {
     }
 
     /**
+     * @notice Makes `checkTransaction` actually revert, as opposed to `revertTransaction` which only
+     *         returns a zero magic value.
+     */
+    function setRevertCheckWithReason(bool revert_) external {
+        revertCheckWithReason = revert_;
+    }
+
+    /**
      * @inheritdoc IPolicy
      * @dev This policy always returns the magic value for a particular access selector.
      */
@@ -45,6 +61,7 @@ contract MockPolicy is IPolicy {
         bytes calldata,
         AccessSelector.T
     ) external view override returns (bytes4 magicValue) {
+        require(!revertCheckWithReason, MockDenied(42));
         return revertTransaction ? magicValue : IPolicy.checkTransaction.selector;
     }
 

--- a/test/allowedModulePolicy.spec.ts
+++ b/test/allowedModulePolicy.spec.ts
@@ -208,9 +208,12 @@ describe('AllowedModulePolicy', function () {
       })
 
       // The module is not in the allowed list, so it should be blocked
-      await expect(
-        unauthorizedModule.executeTx(await safe.getAddress(), target, 0, '0x', SafeOperation.Call)
-      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+      await expect(unauthorizedModule.executeTx(await safe.getAddress(), target, 0, '0x', SafeOperation.Call))
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(
+          await allowedModulePolicy.getAddress(),
+          allowedModulePolicy.interface.encodeErrorResult('UnauthorizedModule', [])
+        )
     })
   })
 })

--- a/test/coSignerPolicy.spec.ts
+++ b/test/coSignerPolicy.spec.ts
@@ -158,7 +158,9 @@ describe('CoSignerPolicy', function () {
           value: amount,
           data: '0x'
         })
-      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+      )
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(await coSignerPolicy.getAddress(), coSignerPolicy.interface.encodeErrorResult('Unauthorized', []))
     })
 
     it('Should not allow transaction with wrong co-signer signature', async function () {
@@ -218,7 +220,9 @@ describe('CoSignerPolicy', function () {
           value: amount,
           additionalData: cosignerSignature.data
         })
-      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+      )
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(await coSignerPolicy.getAddress(), coSignerPolicy.interface.encodeErrorResult('Unauthorized', []))
     })
 
     it('Should allow transaction with different co-signers for different targets', async function () {

--- a/test/erc20ApprovePolicy.spec.ts
+++ b/test/erc20ApprovePolicy.spec.ts
@@ -137,7 +137,12 @@ describe('ERC20ApprovePolicy', function () {
           to: await token.getAddress(),
           data: token.interface.encodeFunctionData('approve', [spender, amount])
         })
-      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+      )
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(
+          await erc20ApprovePolicy.getAddress(),
+          erc20ApprovePolicy.interface.encodeErrorResult('Unauthorized', [])
+        )
     })
 
     it('Should not allow non-approve transactions', async function () {

--- a/test/erc20TransferPolicy.spec.ts
+++ b/test/erc20TransferPolicy.spec.ts
@@ -141,7 +141,12 @@ describe('ERC20TransferPolicy', function () {
           to: await token.getAddress(),
           data: token.interface.encodeFunctionData('transfer', [await other.getAddress(), amount])
         })
-      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+      )
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(
+          await erc20TransferPolicy.getAddress(),
+          erc20TransferPolicy.interface.encodeErrorResult('Unauthorized', [])
+        )
     })
 
     it('Should not allow non-transfer transactions', async function () {

--- a/test/moduleContext.spec.ts
+++ b/test/moduleContext.spec.ts
@@ -133,8 +133,11 @@ describe('Authenticated module parameter', function () {
           .connect(other)
           .execTransaction(to, 0n, '0x', SafeOperation.Call, 0n, 0n, 0n, ZeroAddress, ZeroAddress, signatures)
       )
-        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
-        .withArgs(await allowedModulePolicy.getAddress())
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(
+          await allowedModulePolicy.getAddress(),
+          allowedModulePolicy.interface.encodeErrorResult('InvalidModule', [])
+        )
     })
 
     it('Should deny an owner transaction with no context', async function () {
@@ -148,10 +151,13 @@ describe('Authenticated module parameter', function () {
       )
 
       // `module` is `address(0)` for an owner transaction, so the policy rejects it. The revert
-      // reason is the policy's own `InvalidModule`, surfaced by the engine as `AccessDenied`.
+      // reason is the policy's own `InvalidModule`, forwarded by the engine in `PolicyReverted`.
       await expect(execTransaction({ owners: [owner], safe, to: randomAddress() }))
-        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
-        .withArgs(await allowedModulePolicy.getAddress())
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(
+          await allowedModulePolicy.getAddress(),
+          allowedModulePolicy.interface.encodeErrorResult('InvalidModule', [])
+        )
     })
   })
 
@@ -188,8 +194,11 @@ describe('Authenticated module parameter', function () {
       await testModule.executeTx(await safe.getAddress(), randomAddress(), 0, '0x', SafeOperation.Call)
 
       await expect(execTransaction({ owners: [owner], safe, to: randomAddress() }))
-        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
-        .withArgs(await allowedModulePolicy.getAddress())
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(
+          await allowedModulePolicy.getAddress(),
+          allowedModulePolicy.interface.encodeErrorResult('InvalidModule', [])
+        )
     })
 
     it('Should propagate the module to MultiSend sub-transaction checks', async function () {

--- a/test/multiSendPolicy.spec.ts
+++ b/test/multiSendPolicy.spec.ts
@@ -23,7 +23,8 @@ import {
   deployMultiSendPolicy,
   deployTestERC20Token,
   deployCoSignerPolicy,
-  deployAllowPolicy
+  deployAllowPolicy,
+  deployMockPolicy
 } from './deploy'
 
 describe('MultiSendPolicy', function () {
@@ -323,8 +324,74 @@ describe('MultiSendPolicy', function () {
           operation: SafeOperation.DelegateCall
         })
       )
-        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
-        .withArgs(await multiSendPolicy.getAddress())
+        // Attributed to MultiSendPolicy -- engine-supplied, so trustworthy -- with the
+        // sub-transaction's own denial nested inside as opaque data.
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(
+          await multiSendPolicy.getAddress(),
+          safePolicyGuard.interface.encodeErrorResult('AccessDenied', [ZeroAddress])
+        )
+    })
+
+    it('Should nest a sub-transaction policy revert reason inside the batch attribution', async function () {
+      const { owner, safePolicyGuard, safe, multiSendPolicy, multiSend, allowPolicy, recipient } =
+        await loadFixture(fixture)
+
+      const { mockPolicy } = await deployMockPolicy()
+      const subTarget = randomAddress()
+      const amount = ethers.parseEther('1')
+
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [
+            createConfiguration({ target: recipient.address, policy: await allowPolicy.getAddress() }),
+            createConfiguration({ target: subTarget, policy: await mockPolicy.getAddress() }),
+            createConfiguration({
+              target: await multiSend.getAddress(),
+              selector: multiSend.interface.getFunction('multiSend')?.selector,
+              operation: SafeOperation.DelegateCall,
+              policy: await multiSendPolicy.getAddress()
+            })
+          ]
+        ])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      await mockPolicy.setRevertCheckWithReason(true)
+
+      const txs = [
+        buildSafeTransaction({ to: recipient.address, value: amount, data: '0x', nonce: 0 }),
+        buildSafeTransaction({ to: subTarget as string, value: 0, data: '0x', nonce: 1 })
+      ]
+      const safeTx = await buildMultiSendSafeTx(multiSend, txs, await safe.nonce())
+
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await multiSend.getAddress(),
+          data: safeTx.data,
+          operation: SafeOperation.DelegateCall
+        })
+      )
+        // Each layer's `policy` is engine-supplied, so the attribution cannot be forged by a
+        // policy; the inner policy's own error is carried verbatim as the nested payload.
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(
+          await multiSendPolicy.getAddress(),
+          safePolicyGuard.interface.encodeErrorResult('PolicyReverted', [
+            await mockPolicy.getAddress(),
+            mockPolicy.interface.encodeErrorResult('MockDenied', [42])
+          ])
+        )
     })
 
     it('Should pass with multiple guard transactions to configure without any configured policy', async function () {

--- a/test/nativeTransferPolicy.spec.ts
+++ b/test/nativeTransferPolicy.spec.ts
@@ -124,7 +124,12 @@ describe('NativeTransferPolicy', function () {
           safe,
           to: await recipient.getAddress()
         })
-      ).to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+      )
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(
+          await nativeTransferPolicy.getAddress(),
+          nativeTransferPolicy.interface.encodeErrorResult('InvalidTransfer', [])
+        )
     })
 
     it('Should not allow non-native transfer transactions', async function () {

--- a/test/policyEngine.spec.ts
+++ b/test/policyEngine.spec.ts
@@ -217,4 +217,58 @@ describe('PolicyEngine Edge Cases', function () {
       expect(await accessSelector.getOperation(delegateCallFallback)).to.equal(SafeOperation.DelegateCall)
     })
   })
+
+  describe('Denial reasons', function () {
+    async function guardedFixture() {
+      const base = await loadFixture(fixture)
+      const { owner, safe, safePolicyGuard, mockPolicy } = base
+      const target = randomAddress()
+
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [createConfiguration({ target, policy: await mockPolicy.getAddress() })]
+        ])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      return { ...base, target }
+    }
+
+    it('Should forward a policy own revert data', async function () {
+      const { owner, safe, safePolicyGuard, mockPolicy, target } = await guardedFixture()
+      await mockPolicy.setRevertCheckWithReason(true)
+
+      await expect(execTransaction({ owners: [owner], safe, to: target }))
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(await mockPolicy.getAddress(), mockPolicy.interface.encodeErrorResult('MockDenied', [42]))
+    })
+
+    it('Should report a wrong magic value as AccessDenied, not PolicyReverted', async function () {
+      const { owner, safe, safePolicyGuard, mockPolicy, target } = await guardedFixture()
+
+      // The policy returns successfully but with the wrong magic value, which is a denial rather
+      // than a revert and so keeps the `AccessDenied` shape.
+      await mockPolicy.setRevertTransaction(true)
+
+      await expect(execTransaction({ owners: [owner], safe, to: target }))
+        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+        .withArgs(await mockPolicy.getAddress())
+    })
+
+    it('Should report no configured policy as AccessDenied with the zero address', async function () {
+      const { owner, safe, safePolicyGuard } = await guardedFixture()
+
+      await expect(execTransaction({ owners: [owner], safe, to: randomAddress() }))
+        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+        .withArgs(ZeroAddress)
+    })
+  })
 })


### PR DESCRIPTION
Split the denial errors so a policy that reverts surfaces its own revert data, instead of every failure collapsing into `AccessDenied`.

## Context and Motivation

`catch { revert AccessDenied(policy); }` discarded all return data, and it compounded through recursion: for a MultiSend batch the inner engine's `AccessDenied(realPolicy)` was caught by the outer engine and re-emitted as `AccessDenied(multiSendPolicy)`, so the policy and sub-transaction that actually denied were unknowable on chain. Out-of-gas and a deliberate deny were also indistinguishable.

Worth stating what was *not* wrong: the construction could only ever turn success into denial, never denial into success, because the magic-value `require` sits inside the `try` and an out-of-gas policy call leaves the outer frame enough gas to revert. There was no bypass here; the cost was purely diagnostic.

## Decisions and Tradeoffs

- `PolicyReverted(policy, reason)` is separate from `AccessDenied(policy)` rather than replacing it, because they describe different situations. `AccessDenied` keeps its meaning for no policy being configured (`address(0)`) and for a policy that returns the wrong magic value — which is not hypothetical: `DenyPolicy` denies by returning zero rather than reverting, and its test passes unchanged.
- The caught data is wrapped once, unconditionally. An earlier revision re-threw it verbatim when it already began with an engine error's selector, to keep the root cause intact through `MultiSendPolicy`'s recursion. That is forgeable: selectors are public, so a policy can revert with `AccessDenied(someOtherPolicy)` and the engine would forward it unchanged, making the policy named in the top-level error untrustworthy — precisely the property this change exists to provide. Diagnostics-only impact, but it falsified the guarantee.
- No marker mechanism can rescue the re-throw: any selector is forgeable, and state written in a frame that reverts is discarded, transient storage included, so the engine cannot attest its own nested revert. Wrapping unconditionally makes every layer's `policy` engine-supplied and the nesting visible.
- No cap on the reason length, and no assembly. A policy returning enormous revert data causes an out-of-gas in the catch, which still reverts a transaction that was already reverting, paid for by its submitter. Nesting adds roughly one error frame per level and realistic MultiSend nesting is one to three deep; depths large enough to matter already exhaust gas on the 63/64 rule. Capping the copy would mean replacing `try/catch` with a low-level call plus manual `returndatacopy`, trading a small gas concern for hand-rolled assembly in the engine's most security-critical line.
- Trade-off accepted: the top-level error names the outermost policy with the inner data nested inside, rather than surfacing the root cause directly. Attribution that is trustworthy at every layer is worth more than a shorter
payload.

## Testing

Suite 101 passing, build/lint/typecheck green, no compiler warnings.

Updating the existing tests was informative: 10 of the 11 that changed had been asserting only that *something* denied, because the reason was erased. They now assert `PolicyReverted` with the encoded policy error via `encodeErrorResult`, so they verify the reason is genuinely forwarded.

New tests cover a policy's own revert data being forwarded, a wrong magic value staying `AccessDenied`, no configured policy staying `AccessDenied(address(0))`, and a sub-transaction denial being attributed to `MultiSendPolicy` with the inner error nested — which is what proves attribution is engine-supplied at every layer.

`MockPolicy` gained `setRevertCheckWithReason` and a `MockDenied(uint256)` error: the existing `revertTransaction` flag only returns a zero magic value, so there was previously no way to test a policy that actually reverts.