### PR TITLE
test: cover the engine security boundaries

### DIFF
--- a/contracts/test/ReentrantConfigurePolicy.sol
+++ b/contracts/test/ReentrantConfigurePolicy.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.28;
+
+import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
+import {AccessSelector} from "../libraries/AccessSelector.sol";
+
+/**
+ * @title Reentrant Configure Policy
+ * @dev Test-only policy that re-enters the guard's `applyConfiguration` from its own `configure`
+ *      hook, to prove the pending root is consumed before any policy is called. It records the
+ *      revert data so the test can assert which error fired.
+ */
+contract ReentrantConfigurePolicy is IPolicy {
+    bytes public lastReentryError;
+    bool public reenterSucceeded;
+
+    // solhint-disable-next-line private-vars-leading-underscore
+    bytes private $reentrantCalldata;
+
+    /**
+     * @notice Sets the `applyConfiguration` calldata to replay during `configure`.
+     */
+    function setReentrantCalldata(bytes calldata reentrantCalldata) external {
+        $reentrantCalldata = reentrantCalldata;
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     */
+    function checkTransaction(
+        address,
+        address,
+        uint256,
+        bytes calldata,
+        Operation,
+        address,
+        bytes calldata,
+        AccessSelector.T
+    ) external pure override returns (bytes4 magicValue) {
+        return IPolicy.checkTransaction.selector;
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     */
+    function configure(address, AccessSelector.T, bytes memory) external override returns (bool) {
+        // Deliberately a low-level call: the point is to replay arbitrary calldata against the
+        // guard mid-configuration and observe the revert rather than propagate it.
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returnData) = msg.sender.call($reentrantCalldata);
+        if (success) {
+            reenterSucceeded = true;
+        } else {
+            lastReentryError = returnData;
+        }
+
+        return true;
+    }
+}

--- a/contracts/test/ReentrantMockPolicy.sol
+++ b/contracts/test/ReentrantMockPolicy.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {IPolicyEngine} from "../interfaces/IPolicyEngine.sol";
+import {ISafeModuleGuard} from "../interfaces/ISafeModuleGuard.sol";
 import {ISafeTransactionGuard} from "../interfaces/ISafeTransactionGuard.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";
 
@@ -18,6 +19,8 @@ import {AccessSelector} from "../libraries/AccessSelector.sol";
  *        mechanism).
  *      - `WriteState`: mutates its own state, to stand in for a stateful policy and to prove
  *        stateful writes commit.
+ *      - `ReenterModuleGuardEntry`: re-enters the module-guard entry — the counterpart of
+ *        `ReenterGuardEntry`, also expected to be blocked by `Reentrancy`.
  *      For the re-entry modes it catches any revert and records the returned error data (and
  *      whether the re-entry succeeded) so tests can assert which guard fired, then returns the
  *      magic value so the outer check still succeeds.
@@ -27,7 +30,8 @@ contract ReentrantMockPolicy is IPolicy {
         None,
         ReenterGuardEntry,
         ReenterEngine,
-        WriteState
+        WriteState,
+        ReenterModuleGuardEntry
     }
 
     Mode public mode;
@@ -94,6 +98,14 @@ contract ReentrantMockPolicy is IPolicy {
             }
         } else if (mode == Mode.WriteState) {
             writes++;
+        } else if (mode == Mode.ReenterModuleGuardEntry) {
+            try ISafeModuleGuard(msg.sender).checkModuleTransaction(to, value, data, operation, address(this)) returns (
+                bytes32
+            ) {
+                revert ReentryDidNotRevert();
+            } catch (bytes memory err) {
+                lastReentryError = err;
+            }
         }
 
         return IPolicy.checkTransaction.selector;

--- a/test/policyEngine.spec.ts
+++ b/test/policyEngine.spec.ts
@@ -11,7 +11,7 @@ import {
   randomSelector,
   createConfiguration
 } from '../src/utils'
-import { deploySafeContracts, deploySafePolicyGuard, deployMockPolicy } from './deploy'
+import { deployAllowPolicy, deploySafeContracts, deploySafePolicyGuard, deployMockPolicy } from './deploy'
 
 describe('PolicyEngine Edge Cases', function () {
   async function fixture() {
@@ -215,6 +215,67 @@ describe('PolicyEngine Edge Cases', function () {
       expect(await accessSelector.getTarget(delegateCallFallback)).to.equal(ZeroAddress)
       expect(await accessSelector.getSelector(delegateCallFallback)).to.equal('0x00000000')
       expect(await accessSelector.getOperation(delegateCallFallback)).to.equal(SafeOperation.DelegateCall)
+    })
+  })
+
+  describe('Policy selection', function () {
+    it('Should prefer an exact match over the fallback', async function () {
+      const { owner, safe, safePolicyGuard, mockPolicy } = await loadFixture(fixture)
+      const { allowPolicy } = await deployAllowPolicy()
+      const target = randomAddress()
+
+      // The fallback denies (MockPolicy returns a zero magic value) and the exact match allows, so
+      // a success can only mean the exact match was selected.
+      await mockPolicy.setRevertTransaction(true)
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [
+            createConfiguration({ policy: await mockPolicy.getAddress() }),
+            createConfiguration({ target, policy: await allowPolicy.getAddress() })
+          ]
+        ])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      await expect(execTransaction({ owners: [owner], safe, to: target })).to.not.be.reverted
+
+      // Any other target falls through to the denying fallback.
+      await expect(execTransaction({ owners: [owner], safe, to: randomAddress() }))
+        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+        .withArgs(await mockPolicy.getAddress())
+    })
+
+    it('Should not let a DELEGATECALL fallback authorize a CALL', async function () {
+      const { owner, safe, safePolicyGuard } = await loadFixture(fixture)
+      const { allowPolicy } = await deployAllowPolicy()
+
+      // The operation is part of the access selector, so the two fallbacks are separate keys.
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
+          [createConfiguration({ operation: SafeOperation.DelegateCall, policy: await allowPolicy.getAddress() })]
+        ])
+      })
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safe.getAddress(),
+        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+      })
+
+      await expect(execTransaction({ owners: [owner], safe, to: randomAddress() }))
+        .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
+        .withArgs(ZeroAddress)
     })
   })
 

--- a/test/reentrancy.spec.ts
+++ b/test/reentrancy.spec.ts
@@ -1,17 +1,27 @@
-import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers'
 import { expect } from 'chai'
 import { ZeroAddress, id } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { createConfiguration, createSafe, execTransaction, randomAddress } from '../src/utils'
-import { deploySafeContracts, deploySafePolicyGuard } from './deploy'
+import {
+  SafeOperation,
+  createConfiguration,
+  createSafe,
+  execTransaction,
+  getConfigurationRoot,
+  getSafeTransactionHash,
+  preApprovedSignature,
+  randomAddress
+} from '../src/utils'
+import { deployAllowPolicy, deploySafeContracts, deploySafePolicyGuard } from './deploy'
 
 // Mirrors ReentrantMockPolicy.Mode.
 enum Mode {
   None,
   ReenterGuardEntry,
   ReenterEngine,
-  WriteState
+  WriteState,
+  ReenterModuleGuardEntry
 }
 
 describe('Non-view check path — reentrancy & Safe confinement', function () {
@@ -148,5 +158,93 @@ describe('Non-view check path — reentrancy & Safe confinement', function () {
     expect(await policy.writes()).to.equal(0n)
     await execTransaction({ owners: [ownerA], safe: safeA, to: randomAddress() })
     expect(await policy.writes()).to.equal(1n)
+  })
+
+  it('Should block a policy re-entering the module-guard entry (Reentrancy)', async function () {
+    const { ownerA, safePolicyGuard, safeA } = await loadFixture(fixture)
+
+    // The counterpart of the transaction-guard case above: both entry points call `_enterCheck`.
+    const policy = await deployReentrantPolicy()
+    await policy.setMode(Mode.ReenterModuleGuardEntry)
+    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
+      createConfiguration({ policy: await policy.getAddress() })
+    ])
+
+    await execTransaction({ owners: [ownerA], safe: safeA, to: randomAddress() })
+
+    expect((await policy.lastReentryError()).slice(0, 10)).to.equal(id('Reentrancy()').slice(0, 10))
+  })
+
+  it('Should reject re-entering applyConfiguration from a policy configure hook', async function () {
+    const { ownerA, safePolicyGuard, safeA } = await loadFixture(fixture)
+
+    const policy = await (await ethers.getContractFactory('ReentrantConfigurePolicy')).deploy()
+    const configurations = [createConfiguration({ target: randomAddress(), policy: await policy.getAddress() })]
+    const applyCalldata = safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configurations])
+    await policy.setReentrantCalldata(applyCalldata)
+
+    await execTransaction({
+      owners: [ownerA],
+      safe: safeA,
+      to: await safePolicyGuard.getAddress(),
+      data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [getConfigurationRoot(configurations)])
+    })
+    await time.increase(await safePolicyGuard.DELAY())
+
+    // `applyConfiguration` deletes the pending root before calling any policy, so the policy's
+    // re-entry finds nothing to apply and cannot replay the configuration.
+    await execTransaction({
+      owners: [ownerA],
+      safe: safeA,
+      to: await safePolicyGuard.getAddress(),
+      data: applyCalldata
+    })
+
+    expect(await policy.reenterSucceeded()).to.equal(false)
+    expect((await policy.lastReentryError()).slice(0, 10)).to.equal(id('RootNotConfigured(bytes32)').slice(0, 10))
+  })
+
+  it('Should allow a guarded Safe to execute a transaction on another guarded Safe', async function () {
+    // The gate must not over-block: `_exitCheck` runs before execution begins, so a nested guarded
+    // execution is a fresh top-level check rather than a reentrant one.
+    const { ownerA, ownerB, safePolicyGuard, safeA, safeB } = await loadFixture(fixture)
+    const { allowPolicy } = await deployAllowPolicy()
+
+    const innerTarget = randomAddress()
+    await configureAndEnableGuard(ownerB, safeB, safePolicyGuard, [
+      createConfiguration({ target: innerTarget, policy: await allowPolicy.getAddress() })
+    ])
+    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
+      createConfiguration({
+        target: await safeB.getAddress(),
+        selector: safeB.interface.getFunction('execTransaction')?.selector,
+        policy: await allowPolicy.getAddress()
+      })
+    ])
+
+    // Safe B's owner pre-approves the inner hash so that Safe A can be the executor.
+    const innerHash = await getSafeTransactionHash({ safe: safeB, to: innerTarget })
+    await safeB.connect(ownerB).approveHash(innerHash)
+    const preApproved = await preApprovedSignature(ownerB)
+
+    await expect(
+      execTransaction({
+        owners: [ownerA],
+        safe: safeA,
+        to: await safeB.getAddress(),
+        data: safeB.interface.encodeFunctionData('execTransaction', [
+          innerTarget,
+          0n,
+          '0x',
+          SafeOperation.Call,
+          0n,
+          0n,
+          0n,
+          ZeroAddress,
+          ZeroAddress,
+          preApproved
+        ])
+      })
+    ).to.not.be.reverted
   })
 })

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -4,10 +4,13 @@ import { ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
 import {
+  buildMultiSendSafeTx,
+  buildSafeTransaction,
   createConfiguration,
   createSafe,
   execTransaction,
   getConfigurationRoot,
+  getGuard,
   POLICY_CONTEXT_TYPE_HASH,
   preApprovedSignature,
   randomAddress,
@@ -52,6 +55,22 @@ describe('SafePolicyGuard', function () {
     const accessSelector = await AccessSelectorFactory.deploy()
 
     return { owner, other, safePolicyGuard, safe, delay, mockPolicy, accessSelector }
+  }
+
+  /** Installs `configurations` before the guard, then enables the transaction guard. */
+  async function enableGuardWithPolicy(owner: any, safe: any, safePolicyGuard: any, configurations: unknown[]) {
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: await safePolicyGuard.getAddress(),
+      data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+    })
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: await safe.getAddress(),
+      data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+    })
   }
 
   describe('constructor', function () {
@@ -955,6 +974,33 @@ describe('SafePolicyGuard', function () {
       ).to.be.revertedWithCustomError(safePolicyGuard, 'NonZeroSafeTxGas')
     })
 
+    it('Should revert when safeTxGas is non-zero through a Safe execution', async function () {
+      // The unit test above asserts the ordering (rejected before policy lookup, since no policy is
+      // configured there); this one asserts the Safe actually forwards `safeTxGas` to the guard.
+      const { owner, safePolicyGuard, safe, mockPolicy } = await loadFixture(fixture)
+      const target = randomAddress()
+      await enableGuardWithPolicy(owner, safe, safePolicyGuard, [
+        createConfiguration({ target, policy: await mockPolicy.getAddress() })
+      ])
+
+      await expect(
+        execTransaction({ owners: [owner], safe, to: target, safeTxGas: 100_000n })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'NonZeroSafeTxGas')
+    })
+
+    it('Should revert when gasPrice is non-zero', async function () {
+      const { owner, safePolicyGuard, safe, mockPolicy } = await loadFixture(fixture)
+      const target = randomAddress()
+      await enableGuardWithPolicy(owner, safe, safePolicyGuard, [
+        createConfiguration({ target, policy: await mockPolicy.getAddress() })
+      ])
+
+      await expect(execTransaction({ owners: [owner], safe, to: target, gasPrice: 1n })).to.be.revertedWithCustomError(
+        safePolicyGuard,
+        'NonZeroGasPrice'
+      )
+    })
+
     it('Should revert a direct engine checkTransaction outside a top-level check (NotChecking)', async function () {
       const { safePolicyGuard, safe } = await loadFixture(fixture)
 
@@ -995,6 +1041,70 @@ describe('SafePolicyGuard', function () {
       await expect(testModule.executeTx(await safe.getAddress(), randomAddress(), 0, '0x', SafeOperation.Call))
         .to.be.revertedWithCustomError(safePolicyGuard, 'AccessDenied')
         .withArgs(ZeroAddress)
+    })
+  })
+
+  describe('Guard removal', function () {
+    it('Should remove the guard after the delay via a single batch', async function () {
+      // The documented flow: request an AllowPolicy for `setGuard`, wait out the delay, then apply
+      // it and remove the guard in one MultiSend.
+      const { owner, safePolicyGuard, safe, delay } = await loadFixture(fixture)
+      const { allowPolicy } = await deployAllowPolicy()
+      const { multiSend } = await deploySafeContracts()
+
+      await enableGuardWithPolicy(owner, safe, safePolicyGuard, [
+        createConfiguration({
+          target: await multiSend.getAddress(),
+          selector: multiSend.interface.getFunction('multiSend')?.selector,
+          operation: SafeOperation.DelegateCall,
+          policy: await allowPolicy.getAddress()
+        })
+      ])
+
+      const configurations = [
+        createConfiguration({
+          target: await safe.getAddress(),
+          selector: safe.interface.getFunction('setGuard')?.selector,
+          policy: await allowPolicy.getAddress()
+        })
+      ]
+
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [
+          getConfigurationRoot(configurations)
+        ])
+      })
+      await time.increase(delay)
+
+      const batch = await buildMultiSendSafeTx(
+        multiSend,
+        [
+          buildSafeTransaction({
+            to: await safePolicyGuard.getAddress(),
+            data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configurations]),
+            nonce: 0
+          }),
+          buildSafeTransaction({
+            to: await safe.getAddress(),
+            data: safe.interface.encodeFunctionData('setGuard', [ZeroAddress]),
+            nonce: 1
+          })
+        ],
+        await safe.nonce()
+      )
+
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await multiSend.getAddress(),
+        data: batch.data,
+        operation: SafeOperation.DelegateCall
+      })
+
+      expect(await getGuard(safe)).to.equal(ZeroAddress)
     })
   })
 


### PR DESCRIPTION
Close the coverage gaps the audit-readiness review found, adding the tests to the suites that already own each subject.

## Context and Motivation

Several load-bearing controls had no test. `gasPrice != 0` — the restriction that makes "the engine can never move Safe funds" true — was entirely unasserted. Fallback dispatch was only tested through `getPolicy`'s returned key, never by actually dispatching a transaction. The documented guard-removal flow had no test at all. The module-guard entry point was never exercised for reentrancy, only the transaction entry. And nothing checked that the reentrancy gate does not *over*-block.

## Decisions and Tradeoffs

- Tests go into the existing suites rather than a new file. An earlier draft added `test/engineSecurity.spec.ts`, which duplicated the `safeA`/`safeB` fixture and guard-enabling helper that `reentrancy.spec.ts` already provides — a sign it was organised by why the tests were written rather than by what they test.
- The exact-match test configures a *denying* fallback, so a pass can only mean the exact policy was selected, not that the fallback happened to allow.
- The end-to-end `safeTxGas` test is kept alongside the existing direct-call one rather than replacing it: that one runs with no policy configured and still gets `NonZeroSafeTxGas` instead of `AccessDenied`, which proves the check fires before policy lookup — ordering the integration test cannot distinguish. A comment now records why both exist.
- Four candidate tests were dropped as redundant: "works with both gas params at zero" (the `execTransaction` defaults mean every other test asserts it), "uses the fallback when no exact match exists" (already load-bearing in four suites), and the apply-before-delay and apply-after-invalidate cases (already asserted by the existing `RootConfigurationPending` and `RootNotConfigured` tests, and composing two covered steps through the same branch is not new coverage).

## Testing

Suite 108 passing (100 + 8), build/lint/typecheck green, no compiler warnings.

Verified the tests are not passing by construction: with `_exitCheck` stubbed out to a no-op, 5 tests fail, including the nested Safe-to-Safe case at `_enterCheck` with `Reentrancy` — the exact failure mode it exists to catch.

`ReentrantMockPolicy` gained a `ReenterModuleGuardEntry` mode, and a new `ReentrantConfigurePolicy` replays caller-supplied calldata against the guard from inside `configure`, which `MockPolicy` could not do because its `configure` is `view`.