### PR TITLE
docs: document the dual-guard requirement and check-input trust levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ interface IPolicy {
 }
 ```
 
-A policy is a stripped down version of the Safe transaction guard interface, supporting only the pre-transaction checks, as well as only the common transaction data to regular Safe transactions and Safe module transactions. This means that Safe transaction gas refund parameters cannot be checked, and to work around this, we require that `gasPrice == 0` in the Safe guard to ensure that there is no gas refund payment.
+A policy is a stripped down version of the Safe transaction guard interface, supporting only the pre-transaction checks, as well as only the common transaction data to regular Safe transactions and Safe module transactions. This means that Safe transaction gas refund parameters cannot be checked, and to work around this, we require that `gasPrice == 0` in the Safe guard to ensure that there is no gas refund payment. With `gasPrice == 0` the Safe skips its payment step entirely, so `baseGas`, `gasToken` and `refundReceiver` cannot move value and need no policy check. A consequence of the reduced parameter set is that a policy cannot reconstruct the exact Safe transaction hash, so policies cannot bind to it.
 
-The policy is **not** a `view` method and is allowed to make state changes, enabling stateful policies (for example, accounting or rate-limiting). Checks are **pre-execution only** — the `checkAfterExecution` / `checkAfterModuleExecution` hooks are intentionally no-ops — so any state a policy writes during the check is committed with the transaction regardless of what the transaction itself does afterwards. To keep that state consistent with the execution outcome, the Safe guard additionally requires `safeTxGas == 0`: a non-zero `safeTxGas` lets a Safe transaction whose inner call fails complete without reverting, which would leave a policy's staged state committed against a failed action. Forbidding it ensures a failed execution reverts the whole transaction (and the policy's writes) atomically.
+The policy is **not** a `view` method and is allowed to make state changes, enabling stateful policies (for example, accounting or rate-limiting). Policy *checks* are **pre-execution only** — a policy is never re-invoked afterwards — so any state a policy writes during the check is committed with the transaction. Keeping that state consistent with the execution outcome therefore requires that a failed execution reverts the whole transaction, which the guard enforces on both authorization paths:
+
+* **Transaction path:** `safeTxGas == 0` is required. A non-zero `safeTxGas` lets a Safe transaction whose inner call fails complete without reverting, which would leave a policy's staged state committed against a failed action.
+* **Module path:** there is no `safeTxGas` equivalent — `execTransactionFromModule` returns `false` instead of reverting — so `checkAfterModuleExecution` reverts when execution failed. `checkAfterExecution` does the same on the transaction path. That hook still runs on a successful transaction; what it cannot observe while `safeTxGas` and `gasPrice` are zero is a *failure*, because the Safe reverts before calling it. It exists so atomicity is enforced locally rather than assumed of the Safe version in use.
+
+Without the module-path check, an attacker able to trigger a module could exhaust a stateful policy's budget with calls engineered to fail, moving no funds.
 
 For any transaction executed by a Safe (be it a regular transaction or a module transaction), a policy MUST be configured, and the `checkTransaction` function MUST return the 4-byte magic value (equal to `IPolicy.checkTransaction.selector`).
 
@@ -38,12 +43,32 @@ Because `checkTransaction` may mutate state, the guard invokes policies with a `
 
 Within a *single* Safe, however, a policy can trigger checks of that same Safe's other policies — this is exactly the mechanism `MultiSendPolicy` relies on. That surface is therefore bounded to the Safe's own configured (and, per the trust model, audited) policy set: a policy a Safe installs can drive that Safe's other policies, but nothing on any other Safe. Policies must key their state by `(msg.sender, safe)` per the `IPolicy.checkTransaction` security contract so they cannot be driven from an unexpected namespace.
 
+#### Trusting the check inputs
+
+Two of the arguments a policy receives have very different trust levels, and conflating them is a privilege-escalation bug:
+
+* **`module`** is supplied by the engine from the guard entry point — `address(0)` for an owner transaction, otherwise the module that authorized it. It is held in engine state rather than passed through the recursive entry point, so a policy driving a recursive check cannot forge it. This is the *only* trustworthy indicator of the authorization path.
+* **`context`** is caller-supplied and **untrusted on every path**. On the transaction path it is carried in the tail of the Safe `signatures` bytes, which the Safe transaction hash does not cover and whose trailing bytes Safe ignores — so *any* executor, including a relayer that signed nothing, chooses it freely. On the module path it is always empty.
+
+A policy must therefore treat `context` only as self-authenticating material — a signature over a hash the policy recomputes, say — and never as an identity or authorization claim. `AllowedModulePolicy` reads `module`, not `context`, for exactly this reason.
+
+Context is carried using the [`SignatureExtension`](./contracts/libraries/SignatureExtension.sol) envelope, `[payload][uint256 payloadLength][bytes32 typeHash]`. The type hash is the terminal word rather than a length, so unrelated trailing data — an EIP-1271 contract signature, for instance — is not mistaken for context. Signatures carrying no envelope are not an error; a blob that claims the type but is malformed is, and denies the transaction.
+
 Policy authors MUST uphold the following to keep those guarantees:
 
 * Prefer no external calls. If reading external state, use a `STATICCALL` (e.g. a `view` helper such as OpenZeppelin's `SignatureChecker`) so the callee cannot reenter.
 * Never make a state-mutating external call to an untrusted address during a check.
 * Write only to storage namespaced by `(policyGuard, safe)`.
+* Authorize on `to` and `data`, not on `access`. When a policy is reached through a fallback, `access` is the fallback key — target `address(0)` and selector `0x00000000` — not the transaction's real target and selector.
 * Follow checks-effects-interactions and bound gas and storage growth.
+
+#### Accepted limitations
+
+These are known and deliberate. All of them fail closed — they deny or revert rather than letting something through — but they shape what is expressible:
+
+* **A transaction carrying 1–3 bytes of calldata is always rejected** with `InvalidSelector`, because no function selector can be decoded from it. Empty calldata is fine and decodes to the zero selector.
+* **The fallback key is indistinguishable from a real access selector for `address(0)`.** `create(address(0), bytes4(0), operation)` and `createFallback(operation)` are the same value, so a plain value transfer to `address(0)` resolves to the catch-all policy. A fallback policy therefore also authorizes burning value to the zero address.
+* **`MultiSendPolicy` pairs contexts with sub-transactions positionally** and yields an empty context once the supplied list is exhausted. A batch cannot give context to only its last sub-transaction without padding the earlier ones.
 
 ### Access Selectors
 
@@ -94,13 +119,41 @@ In principle, this provides similar features to what a Zodiac `Roles` modifier a
 2. Individual policies can be complicated, and as a general rule `Roles` configurations aren't audited which is a potential security risk
 3. Policy implementations can be independently audited and formally verified
 
+## Setup with Safe
+
+> [!IMPORTANT]
+> The `SafePolicyGuard` must be installed as **both** the transaction guard and the module guard. Installing only one leaves a complete bypass of the policy system, and the guard cannot detect or prevent this itself.
+
+Safe keeps the two guards in separate storage slots, set by two separate calls:
+
+- `setGuard(policyGuard)` — checks owner transactions (`execTransaction`).
+- `setModuleGuard(policyGuard)` — checks module transactions (`execTransactionFromModule` and `execTransactionFromModuleReturnData`).
+
+With only the transaction guard installed, **any enabled module executes with no policy enforcement at all** — including calling `setGuard(address(0))` to remove the guard outright, with none of the configuration delay. The reverse holds too: with only the module guard installed, owner transactions are unchecked.
+
+So the hardening sequence is:
+
+1. Configure the intended policies with `configureImmediately(...)`, while no guard is installed.
+2. Install **both** guards, ideally atomically via MultiSend so there is no window with only one active.
+
+Two things to check when hardening an existing Safe:
+
+- **Modules enabled before hardening are unconstrained until the module guard is set.** Enumerate them first; `enableModule` afterwards requires a configured policy, but existing modules do not.
+- `configureImmediately` is rejected once either guard points at the policy guard, so all configuration after this point goes through the delay. Bootstrap fully before installing the guards.
+
 ## Guard Removal
 
 To remove a guard, instead of baking in the delay mechanism within the guard contract, we use the delay mechanism which is already present for any policy to get activated. To remove a guard:
 - We `requestConfiguration(...)` with the `configureRoot` as the data with [AllowPolicy](./contracts/policies/AllowPolicy.sol) and selector as `setGuard(...)`, target as Safe itself, and operation as `CALL`
 - Once the delay is over, we can apply the policy using `applyConfiguration(...)` and also remove the Guard (we can use MultiSend for the same to do in a single transaction).
 
-Note: If the Safe reactivates the guard, this policy should be removed (can be done without any delay with `configureImmediately(...)` before the guard is enabled) 
+Removing the module guard works the same way, with `setModuleGuard(...)` as the selector. Remove **both** if the intent is to uninstall the policy engine; removing only one leaves the Safe partly guarded rather than unguarded.
+
+Note: If the Safe reactivates the guard, this policy should be removed. This needs `configureImmediately(...)` while no guard is installed — once either guard is set, `configureImmediately` reverts `GuardAlreadyEnabled` and the delay applies.
+
+## Deployment note
+
+Every change to the guard changes its bytecode and therefore its CREATE2 address. Existing deployments must be redeployed and Safes re-pointed at the new address; a Safe keeps referencing whichever address it was given.
 
 ## Testing
 

--- a/contracts/core/PolicyEngine.sol
+++ b/contracts/core/PolicyEngine.sol
@@ -193,8 +193,10 @@ abstract contract PolicyEngine is IPolicyEngine {
      * @dev Reverts if a top-level check is already in progress. Since the Safe invokes the guard on
      *      every execution, this also stops a policy from re-entering the Safe to run another
      *      guarded transaction mid-check. It does not by itself restrict calls to the configuration
-     *      functions — those stay safe because their state is keyed by `msg.sender`. Kept as shared
-     *      functions rather than a modifier to avoid duplicating the guard bytecode at each entry.
+     *      functions — those stay safe because their state is keyed by `msg.sender`. Nor does it
+     *      stop a policy driving checks of the same Safe's other policies; see {checkTransaction}.
+     *      Kept as shared functions rather than a modifier to avoid duplicating the guard bytecode
+     *      at each entry.
      */
     function _enterCheck(address safe, address module) internal {
         require($checkingSafe == address(0), Reentrancy());

--- a/contracts/interfaces/IPolicy.sol
+++ b/contracts/interfaces/IPolicy.sol
@@ -50,6 +50,10 @@ interface IPolicy {
      * @param access The access selector for the transaction.
      * @param data Additional data for the policy configuration.
      * @return success Indicates whether the configuration was successful.
+     * @dev Reachable by **any** address for itself: `configureImmediately` passes its caller as
+     *      `safe`, so `safe`, `access` and `data` are all caller-chosen and `safe` need not be a
+     *      Safe. Namespace state by `(msg.sender, safe)` as for {checkTransaction}, and validate
+     *      `access` and `data` rather than assuming a configuration flow produced them.
      */
     function configure(address safe, AccessSelector.T access, bytes memory data) external returns (bool success);
 }


### PR DESCRIPTION
Correct the claims this stack invalidated, and document the two things a reader could previously get wrong in a security-relevant way: that both Safe guards are required, and that `context` is untrusted while `module` is not.

## Context and Motivation

Two existing statements became false during this stack. The `safeTxGas == 0` paragraph claimed flatly that forbidding it "ensures a failed execution reverts the whole transaction atomically", which was only ever true on the transaction path — the module-path gap is what an earlier PR in this stack fixed. The same paragraph described the after-execution hooks as intentional no-ops, which they no longer are.

The dual-guard requirement is the one finding from the review that cannot be fixed in the guard: Safe keeps the transaction and module guards in separate slots, and this contract has no way to detect that only one is installed. With just the transaction guard, any enabled module executes with no policy enforcement at all, including removing the guard outright with none of the delay. That makes documentation the mitigation, so it needs to be prominent rather than implied.

## Decisions and Tradeoffs

- The atomicity paragraph is split per authorization path rather than reworded, because the two paths achieve it by different mechanisms and a single sentence was what made the original claim wrong.
- "Checks are pre-execution only" becomes "policy *checks* are pre-execution only — a policy is never re-invoked afterwards". That is the property that still holds and no longer conflates it with the hooks being empty.
- The setup section documents the two traps specific to hardening an *existing* Safe: modules enabled beforehand stay unconstrained until the module guard is set, and `configureImmediately` closes as soon as either guard is installed.
- `access` degrading to the fallback key under fallback dispatch is documented rather than changed. No current policy reads `access` in `checkTransaction`, so this is latent, but a future policy authorizing on it would be bypassable.
- `IPolicy.configure` gains the security contract it never had: it is reachable by any address for itself, so `safe`, `access` and `data` are all caller-chosen and `safe` need not be a Safe.

## Testing

Docs and NatSpec only; suite 108 passing, build/lint/typecheck green.

Each factual claim is backed by code or a test: `GuardAlreadyEnabled` is asserted for the module-guard-only case, the `handlePayment` skip is why `baseGas`, `gasToken` and `refundReceiver` need no policy check, and the malformed-envelope-denies behaviour has its own test. The one statement without a test is that module-guard removal works via `setModuleGuard` as the selector, which follows from `_allowedCalls` and the access-selector mechanism.