### PR TITLE
feat: add RootApplied event and emit it on configuration application

### DIFF
--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -120,6 +120,13 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
     event RootInvalidated(address indexed safe, bytes32 indexed root);
 
     /**
+     * @notice Emitted when a policy root is applied.
+     * @param safe The address of the Safe.
+     * @param root The root is a hash of the policy configurations.
+     */
+    event RootApplied(address indexed safe, bytes32 indexed root);
+
+    /**
      * @param delay The delay for the configuration change.
      */
     constructor(uint256 delay) {
@@ -341,13 +348,15 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
     /**
      * @notice Applies a policy configuration change.
      * @param configurations The array of configurations to be applied.
-     * @dev This can be used to set multiple policies at once.
+     * @dev This can be used to set multiple policies at once. {RootApplied} is emitted before the
+     *      individual {PolicyConfirmed} logs, so indexer can attribute them to the root.
      */
     function applyConfiguration(Configuration[] calldata configurations) external virtual {
         bytes32 configureRoot = keccak256(abi.encode(configurations));
         require(rootConfigured[msg.sender][configureRoot] != 0, RootNotConfigured(configureRoot));
         require(block.timestamp >= rootConfigured[msg.sender][configureRoot], RootConfigurationPending());
         delete rootConfigured[msg.sender][configureRoot];
+        emit RootApplied(msg.sender, configureRoot);
         for (uint256 i = 0; i < configurations.length; i++) {
             _confirmPolicy(
                 msg.sender,

--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -349,7 +349,7 @@ contract SafePolicyGuard is PolicyEngine, ISafeModuleGuard, ISafeTransactionGuar
      * @notice Applies a policy configuration change.
      * @param configurations The array of configurations to be applied.
      * @dev This can be used to set multiple policies at once. {RootApplied} is emitted before the
-     *      individual {PolicyConfirmed} logs, so indexer can attribute them to the root.
+     *      individual {PolicyConfirmed} logs, so an indexer can attribute them to the root.
      */
     function applyConfiguration(Configuration[] calldata configurations) external virtual {
         bytes32 configureRoot = keccak256(abi.encode(configurations));

--- a/contracts/test/App/AppSafePolicyGuard.sol
+++ b/contracts/test/App/AppSafePolicyGuard.sol
@@ -125,6 +125,7 @@ contract AppSafePolicyGuard is SafePolicyGuard {
         delete rootConfigured[msg.sender][configureRoot];
         _configureRoots[msg.sender].remove(configureRoot);
         delete _configurations[configureRoot];
+        emit RootApplied(msg.sender, configureRoot);
         for (uint256 i = 0; i < configurations.length; i++) {
             _confirmPolicy(
                 msg.sender,

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -779,6 +779,68 @@ describe('SafePolicyGuard', function () {
           configuration[0].data
         )
     })
+
+    it('Should emit an event with the root when the configuration is applied', async function () {
+      const { owner, safePolicyGuard, safe, delay, mockPolicy } = await loadFixture(fixture)
+
+      // Configuration parameters
+      const configuration = [
+        createConfiguration({
+          target: randomAddress(),
+          selector: randomSelector(),
+          policy: await mockPolicy.getAddress()
+        })
+      ]
+
+      // Configuration root
+      const configurationRoot = getConfigurationRoot(configuration)
+
+      // Call the request configuration function on safe using execTransaction helper function
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await safePolicyGuard.getAddress(),
+        data: safePolicyGuard.interface.encodeFunctionData('requestConfiguration', [configurationRoot])
+      })
+
+      // Increase the time to the delay
+      await time.increase(delay)
+
+      // Call the apply configuration function on safe using execTransaction helper function
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await safePolicyGuard.getAddress(),
+          data: safePolicyGuard.interface.encodeFunctionData('applyConfiguration', [configuration])
+        })
+      )
+        .to.emit(safePolicyGuard, 'RootApplied')
+        .withArgs(await safe.getAddress(), configurationRoot)
+    })
+
+    it('Should not emit a root applied event when the configuration is applied without a root', async function () {
+      const { owner, safePolicyGuard, safe, mockPolicy } = await loadFixture(fixture)
+
+      // Configuration parameters
+      const configuration = [
+        createConfiguration({
+          target: randomAddress(),
+          selector: randomSelector(),
+          policy: await mockPolicy.getAddress()
+        })
+      ]
+
+      // `configureImmediately` bypasses the delay and has no root to report
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await safePolicyGuard.getAddress(),
+          data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configuration])
+        })
+      ).to.not.emit(safePolicyGuard, 'RootApplied')
+    })
   })
 
   describe('invalidateRoot', function () {

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -819,7 +819,7 @@ describe('SafePolicyGuard', function () {
         .withArgs(await safe.getAddress(), configurationRoot)
     })
 
-    it('Should not emit a root applied event when the configuration is applied without a root', async function () {
+    it('Should not emit RootApplied when configuring immediately', async function () {
       const { owner, safePolicyGuard, safe, mockPolicy } = await loadFixture(fixture)
 
       // Configuration parameters


### PR DESCRIPTION
Fixes #45 


### Changes

- `event RootApplied(address indexed safe, bytes32 indexed root)`, emitted by `applyConfiguration`
  after the `delete` and before the `_confirmPolicy` loop.
- Same emit in `AppSafePolicyGuard`
- `configureImmediately` deliberately does not emit - it touches no root storage and has no pending
  state.
