### PR TITLE
docs: link IMultiSend to MultiSend instead of ERC-165

### DIFF
--- a/contracts/interfaces/IMultiSend.sol
+++ b/contracts/interfaces/IMultiSend.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.28;
 
 /**
  * @title Multi Send Library Interface
- * @dev <https://eips.ethereum.org/EIPS/eip-165>
+ * @dev The subset of Safe's `MultiSend` library that {MultiSendPolicy} needs in order to recognise
+ *      and decode a batch. See
+ *      <https://github.com/safe-global/safe-smart-account/blob/main/contracts/libraries/MultiSend.sol>.
  */
 interface IMultiSend {
     /**


### PR DESCRIPTION
Closes #62

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).