### PR TITLE
docs: fix ERC-20 policy data param and Unauthorized docs

### DIFF
--- a/contracts/policies/ERC20ApprovePolicy.sol
+++ b/contracts/policies/ERC20ApprovePolicy.sol
@@ -35,7 +35,7 @@ contract ERC20ApprovePolicy is IPolicy {
     error InvalidApproval();
 
     /**
-     * @notice Error indicating the caller is unauthorized.
+     * @notice Error indicating the spender is not on the Safe's allowlist for this token.
      */
     error Unauthorized();
 
@@ -78,7 +78,8 @@ contract ERC20ApprovePolicy is IPolicy {
      * @notice Configure the spender list for a Safe and token.
      * @param safe The Safe address.
      * @param access The access selector.
-     * @param data The spender address.
+     * @param data ABI-encoded {SpenderData} array. Each entry sets or clears one spender, so a
+     *        single call can both allow and revoke.
      * @dev Callable by anyone; state is namespaced by `msg.sender`, keeping the policy engine and policies logically separate.
      */
     function configure(address safe, AccessSelector.T access, bytes memory data) external returns (bool) {

--- a/contracts/policies/ERC20TransferPolicy.sol
+++ b/contracts/policies/ERC20TransferPolicy.sol
@@ -35,7 +35,7 @@ contract ERC20TransferPolicy is IPolicy {
     error InvalidTransfer();
 
     /**
-     * @notice Error indicating the caller is not authorized.
+     * @notice Error indicating the recipient is not on the Safe's allowlist for this token.
      */
     error Unauthorized();
 
@@ -81,7 +81,8 @@ contract ERC20TransferPolicy is IPolicy {
      * @notice Configure the recipient list for a Safe and token.
      * @param safe The Safe address.
      * @param access The access selector.
-     * @param data The recipient address.
+     * @param data ABI-encoded {RecipientData} array. Each entry sets or clears one recipient, so a
+     *        single call can both allow and revoke.
      * @dev Callable by anyone; state is namespaced by `msg.sender`, keeping the policy engine and policies logically separate.
      */
     function configure(address safe, AccessSelector.T access, bytes memory data) external returns (bool) {


### PR DESCRIPTION
data is an ABI-encoded SpenderData[]/RecipientData[]. Unauthorized is the spender or recipient, not the caller.

Closes #61

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).