### PR TITLE
feat(policies): allow revoking modules in AllowedModulePolicy

### DIFF
--- a/contracts/policies/AllowedModulePolicy.sol
+++ b/contracts/policies/AllowedModulePolicy.sol
@@ -50,21 +50,27 @@ contract AllowedModulePolicy is IPolicy {
 
     /**
      * @inheritdoc IPolicy
-     * @dev This policy does not require any configuration.
-     *      QUESTION: Should we allow DELEGATECALLs to be configured?
+     * @param data ABI-encoded `(address module, bool allowed)`. Pass `false` to revoke a module that
+     *        was previously allowed.
+     * @dev Both granting and revoking go through here, so an authorisation can be withdrawn without
+     *      detaching the policy from its access selector. Note the allowlist is namespaced by
+     *      `(msg.sender, safe)` and survives the policy being detached and later re-attached, so a
+     *      revocation must be applied explicitly rather than implied by removing the policy.
      */
     function configure(address safe, AccessSelector.T, bytes memory data) external override returns (bool) {
-        address module = abi.decode(data, (address));
+        (address module, bool allowed) = abi.decode(data, (address, bool));
         // A zero entry would match every owner transaction, making this policy an allow-all.
         require(module != address(0), InvalidModule());
 
-        $allowedModules[msg.sender][safe][module] = true;
+        $allowedModules[msg.sender][safe][module] = allowed;
 
         return true;
     }
 
     /**
      * @notice Check if a module is allowed for a given safe.
+     * @param policyGuard The policy guard that configured the entry. State is namespaced by the
+     *        configuring caller, so reading another namespace returns `false`.
      * @param safe The address of the safe.
      * @param module The address of the module.
      * @return True if the module is allowed, false otherwise.

--- a/test/allowedModulePolicy.spec.ts
+++ b/test/allowedModulePolicy.spec.ts
@@ -52,7 +52,7 @@ describe('AllowedModulePolicy', function () {
       await allowedModulePolicy.connect(owner).configure(
         safeAddress,
         0, // AccessSelector doesn't matter for this policy
-        ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
+        ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [moduleAddress, true])
       )
 
       // Check that the configured module is allowed
@@ -72,7 +72,7 @@ describe('AllowedModulePolicy', function () {
       await allowedModulePolicy.configure(
         safeAddress,
         0, // AccessSelector doesn't matter for this policy
-        ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
+        ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [moduleAddress, true])
       )
 
       // Call checkTransaction and verify it returns the magic value. The module is passed as its
@@ -91,6 +91,43 @@ describe('AllowedModulePolicy', function () {
       // This should match IPolicy.checkTransaction.selector. Derived rather than hardcoded, since
       // the magic value is the selector and therefore moves whenever the signature changes.
       expect(result).to.equal(allowedModulePolicy.interface.getFunction('checkTransaction').selector)
+    })
+
+    it('Should revoke a previously allowed module', async function () {
+      const { owner, safe, allowedModulePolicy, testModule } = await loadFixture(fixture)
+
+      const safeAddress = await safe.getAddress()
+      const moduleAddress = await testModule.getAddress()
+      const encode = (module: string, allowed: boolean) =>
+        ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [module, allowed])
+
+      await allowedModulePolicy.connect(owner).configure(safeAddress, 0, encode(moduleAddress, true))
+      expect(await allowedModulePolicy.isModuleAllowed(owner, safeAddress, moduleAddress)).to.be.true
+
+      // Revoking is expressible without detaching the policy from its access selector.
+      await allowedModulePolicy.connect(owner).configure(safeAddress, 0, encode(moduleAddress, false))
+      expect(await allowedModulePolicy.isModuleAllowed(owner, safeAddress, moduleAddress)).to.be.false
+
+      // …and the grant can be reinstated afterwards.
+      await allowedModulePolicy.connect(owner).configure(safeAddress, 0, encode(moduleAddress, true))
+      expect(await allowedModulePolicy.isModuleAllowed(owner, safeAddress, moduleAddress)).to.be.true
+    })
+
+    it('Should reject a zero module address regardless of the allowed flag', async function () {
+      const { owner, safe, allowedModulePolicy } = await loadFixture(fixture)
+      const safeAddress = await safe.getAddress()
+
+      for (const allowed of [true, false]) {
+        await expect(
+          allowedModulePolicy
+            .connect(owner)
+            .configure(
+              safeAddress,
+              0,
+              ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [ZeroAddress, allowed])
+            )
+        ).to.be.revertedWithCustomError(allowedModulePolicy, 'InvalidModule')
+      }
     })
 
     it('Should revert on checkTransaction for non-allowed module', async function () {
@@ -134,7 +171,7 @@ describe('AllowedModulePolicy', function () {
         createConfiguration({
           target: target,
           policy: await allowedModulePolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [testModuleAddress])
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [testModuleAddress, true])
         })
       ]
 
@@ -187,7 +224,7 @@ describe('AllowedModulePolicy', function () {
         createConfiguration({
           target: target,
           policy: await allowedModulePolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [testModuleAddress])
+          data: ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [testModuleAddress, true])
         })
       ]
 

--- a/test/moduleContext.spec.ts
+++ b/test/moduleContext.spec.ts
@@ -78,7 +78,7 @@ describe('Authenticated module parameter', function () {
         [
           createConfiguration({
             policy: policyAddress,
-            data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
+            data: ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [moduleAddress, true])
           })
         ]
       ])
@@ -236,7 +236,7 @@ describe('Authenticated module parameter', function () {
             createConfiguration({
               target: subTarget,
               policy: await allowedModulePolicy.getAddress(),
-              data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [moduleAddress])
+              data: ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [moduleAddress, true])
             })
           ]
         ])
@@ -279,7 +279,7 @@ describe('Authenticated module parameter', function () {
             [
               createConfiguration({
                 policy: await allowedModulePolicy.getAddress(),
-                data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [ZeroAddress])
+                data: ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [ZeroAddress, true])
               })
             ]
           ])


### PR DESCRIPTION
configure only ever wrote true, and the allowlist outlives detaching the policy, so a module could not be revoked.

BREAKING CHANGE: configure decodes (address module, bool allowed).

Refs #60

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).