### PR TITLE
docs: update README IPolicy signature and selector legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ interface IPolicy {
         uint256 value,
         bytes calldata data,
         Operation operation,
-        bytes calldata context
+        address module,
+        bytes calldata context,
+        AccessSelector.T access
     ) external returns (bytes4 magicValue);
+
+    function configure(address safe, AccessSelector.T access, bytes memory data) external returns (bool success);
 }
 ```
 
@@ -83,7 +87,7 @@ The policy to enforce is chosen based on an _access selectors_. These are simila
 
 * `ssss`: the 4 byte function selector
 * `o`: the operation flag, 0 for `CALL` and 1 for `DELEGATECALL` (just like the function parameter for Safe transactions).
-* `ffffffffffffffffffff`: the address of the contract being (delegate-)called
+* `tttttttttttttttttttt`: the address of the contract being (delegate-)called
 
 Some examples of the access selector for various Safe operations:
 


### PR DESCRIPTION
IPolicy takes module and access. The README used `ffff...` where the diagram uses `tttt....`.

Refs #64

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).