### PR TITLE
docs(interfaces): declare setModuleGuard in ISafe

### DIFF
--- a/contracts/interfaces/ISafe.sol
+++ b/contracts/interfaces/ISafe.sol
@@ -52,6 +52,19 @@ interface ISafe {
     function setGuard(address guard) external;
 
     /**
+     * @dev Set a module guard that checks transactions initiated by the module before execution
+     *      This can only be done via a Safe transaction.
+     *      ⚠️ IMPORTANT: Since a module guard has full power to block transaction execution
+     *        initiated via a module, a broken module guard can cause a denial of service for the
+     *        Safe modules. Make sure to carefully audit the module guard code and design recovery
+     *        mechanisms.
+     * @notice Set Module Guard `moduleGuard` for the Safe. Make sure you trust the module guard.
+     * @param moduleGuard The address of the module guard to be used or the zero address to disable
+     *        the module guard.
+     */
+    function setModuleGuard(address moduleGuard) external;
+
+    /**
      * @notice Reads `length` bytes of storage in the current contract
      * @param offset - the offset in the current contract's storage in words to start reading from
      * @param length - the number of words (32 bytes) of data to read


### PR DESCRIPTION
Closes #64

Third bullet of #64: the README tells operators to call `setModuleGuard(policyGuard)` on the Safe, and `ISafe` already declares its sibling `setGuard`, but not the module counterpart.

Declares it, with natspec taken from Safe 1.5.0's `IModuleManager.setModuleGuard` — the same provenance as the existing `setGuard` entry.

No functional change: nothing in `contracts/` calls either setter. `SafePolicyGuard` uses only `ISafe.getStorageAt`, and reads the module guard slot directly rather than through a setter. This is interface completeness for readers and integrators, which is why the test count is unchanged.

The other two bullets of #64 — the stale `IPolicy` signature and the `ffff`/`tttt` legend — are in #71.

### Stacked

Sits on top of #74. Base will need retargeting if the PRs below merge out of order.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).