### PR TITLE
test: add policy configuration helpers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,6 +96,17 @@ export const EIP712_SAFE_TX_TYPE = {
 export const POLICY_CONTEXT_TYPE_HASH = ethers.id('SafePolicyGuard.PolicyContext.v1')
 
 /**
+ * Encodes `AllowedModulePolicy` configuration data.
+ * @param module The module to grant or revoke.
+ * @param allowed Whether the module is allowed; pass `false` to revoke.
+ * @dev Each policy's configuration shape lives in exactly one place here, so a change to a policy's
+ *      `configure` signature is a one-line change in the tests rather than a hunt through the suite.
+ */
+export function encodeModuleConfig(module: AddressLike, allowed = true): string {
+  return ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [module, allowed])
+}
+
+/**
  * Appends a `SignatureExtension` envelope carrying `payload` to a Safe `signatures` blob.
  * @param signatures The owner signatures.
  * @param payload The policy context to carry in the tail.
@@ -366,6 +377,69 @@ export async function execTransaction({
 export async function calculateSafeMessageHash(safeAddress: string, message: string, chainId: number): Promise<string> {
   return ethers.TypedDataEncoder.hash({ verifyingContract: safeAddress, chainId }, EIP712_SAFE_MESSAGE_TYPE, {
     message
+  })
+}
+
+export type EnableGuardParameters = {
+  owner: Signer
+  safe: Safe
+  safePolicyGuard: SafePolicyGuard
+  configurations?: SafePolicyGuard.ConfigurationStruct[]
+  /** Also install the module guard. Needed for any test exercising the module path. */
+  moduleGuard?: boolean
+  /** Enable this module on the Safe before installing the guards. */
+  module?: string
+}
+
+/**
+ * Configures policies while no guard is installed, then installs the guard(s).
+ * @dev The ordering matters and is the reason this is a helper: `configureImmediately` is rejected
+ *      once either guard points at the policy guard, so all configuration must happen first.
+ *      Replaces the per-file `harden`/`configureAndEnableGuard`/`enableGuardWithPolicy` variants.
+ */
+export async function enableGuard({
+  owner,
+  safe,
+  safePolicyGuard,
+  configurations = [],
+  moduleGuard = false,
+  module
+}: EnableGuardParameters): Promise<void> {
+  const guardAddress = await safePolicyGuard.getAddress()
+  const safeAddress = await safe.getAddress()
+
+  if (configurations.length > 0) {
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: guardAddress,
+      data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
+    })
+  }
+
+  if (module !== undefined) {
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: safeAddress,
+      data: safe.interface.encodeFunctionData('enableModule', [module])
+    })
+  }
+
+  if (moduleGuard) {
+    await execTransaction({
+      owners: [owner],
+      safe,
+      to: safeAddress,
+      data: safe.interface.encodeFunctionData('setModuleGuard', [guardAddress])
+    })
+  }
+
+  await execTransaction({
+    owners: [owner],
+    safe,
+    to: safeAddress,
+    data: safe.interface.encodeFunctionData('setGuard', [guardAddress])
   })
 }
 

--- a/test/allowedModulePolicy.spec.ts
+++ b/test/allowedModulePolicy.spec.ts
@@ -3,7 +3,14 @@ import { expect } from 'chai'
 import { ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { createConfiguration, createSafe, execTransaction, randomAddress, SafeOperation } from '../src/utils'
+import {
+  createConfiguration,
+  createSafe,
+  encodeModuleConfig,
+  execTransaction,
+  randomAddress,
+  SafeOperation
+} from '../src/utils'
 import { deploySafePolicyGuard, deploySafeContracts, deployAllowedModulePolicy } from './deploy'
 
 describe('AllowedModulePolicy', function () {
@@ -52,7 +59,7 @@ describe('AllowedModulePolicy', function () {
       await allowedModulePolicy.connect(owner).configure(
         safeAddress,
         0, // AccessSelector doesn't matter for this policy
-        ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [moduleAddress, true])
+        encodeModuleConfig(moduleAddress)
       )
 
       // Check that the configured module is allowed
@@ -72,7 +79,7 @@ describe('AllowedModulePolicy', function () {
       await allowedModulePolicy.configure(
         safeAddress,
         0, // AccessSelector doesn't matter for this policy
-        ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [moduleAddress, true])
+        encodeModuleConfig(moduleAddress)
       )
 
       // Call checkTransaction and verify it returns the magic value. The module is passed as its
@@ -98,18 +105,15 @@ describe('AllowedModulePolicy', function () {
 
       const safeAddress = await safe.getAddress()
       const moduleAddress = await testModule.getAddress()
-      const encode = (module: string, allowed: boolean) =>
-        ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [module, allowed])
-
-      await allowedModulePolicy.connect(owner).configure(safeAddress, 0, encode(moduleAddress, true))
+      await allowedModulePolicy.connect(owner).configure(safeAddress, 0, encodeModuleConfig(moduleAddress))
       expect(await allowedModulePolicy.isModuleAllowed(owner, safeAddress, moduleAddress)).to.be.true
 
       // Revoking is expressible without detaching the policy from its access selector.
-      await allowedModulePolicy.connect(owner).configure(safeAddress, 0, encode(moduleAddress, false))
+      await allowedModulePolicy.connect(owner).configure(safeAddress, 0, encodeModuleConfig(moduleAddress, false))
       expect(await allowedModulePolicy.isModuleAllowed(owner, safeAddress, moduleAddress)).to.be.false
 
       // …and the grant can be reinstated afterwards.
-      await allowedModulePolicy.connect(owner).configure(safeAddress, 0, encode(moduleAddress, true))
+      await allowedModulePolicy.connect(owner).configure(safeAddress, 0, encodeModuleConfig(moduleAddress))
       expect(await allowedModulePolicy.isModuleAllowed(owner, safeAddress, moduleAddress)).to.be.true
     })
 
@@ -119,13 +123,7 @@ describe('AllowedModulePolicy', function () {
 
       for (const allowed of [true, false]) {
         await expect(
-          allowedModulePolicy
-            .connect(owner)
-            .configure(
-              safeAddress,
-              0,
-              ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [ZeroAddress, allowed])
-            )
+          allowedModulePolicy.connect(owner).configure(safeAddress, 0, encodeModuleConfig(ZeroAddress, allowed))
         ).to.be.revertedWithCustomError(allowedModulePolicy, 'InvalidModule')
       }
     })
@@ -171,7 +169,7 @@ describe('AllowedModulePolicy', function () {
         createConfiguration({
           target: target,
           policy: await allowedModulePolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [testModuleAddress, true])
+          data: encodeModuleConfig(testModuleAddress)
         })
       ]
 
@@ -224,7 +222,7 @@ describe('AllowedModulePolicy', function () {
         createConfiguration({
           target: target,
           policy: await allowedModulePolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [testModuleAddress, true])
+          data: encodeModuleConfig(testModuleAddress)
         })
       ]
 

--- a/test/moduleConfigurationBlocked.spec.ts
+++ b/test/moduleConfigurationBlocked.spec.ts
@@ -8,10 +8,12 @@ import {
   buildMultiSendSafeTx,
   createConfiguration,
   createSafe,
+  enableGuard,
   execTransaction,
   getConfigurationRoot,
   SafeOperation
 } from '../src/utils'
+import type { SafePolicyGuard } from '../typechain-types'
 import { deployAllowPolicy, deployMultiSendPolicy, deploySafeContracts, deploySafePolicyGuard } from './deploy'
 
 /**
@@ -46,27 +48,11 @@ describe('Module policy-change blocking', function () {
     })
 
     /** Installs `cfgs`, then enables both guard slots (module guard first — see below). */
-    async function configurePolicies(cfgs: unknown[] = []) {
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: guardAddress,
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [cfgs])
-      })
-      // Module guard first: once the transaction guard is live, `setModuleGuard` is itself a guarded
-      // self-call needing a configured policy, which this fixture does not install.
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: safeAddress,
-        data: safe.interface.encodeFunctionData('setModuleGuard', [guardAddress])
-      })
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: safeAddress,
-        data: safe.interface.encodeFunctionData('setGuard', [guardAddress])
-      })
+    async function configurePolicies(cfgs: SafePolicyGuard.ConfigurationStruct[] = []) {
+      // `enableGuard` installs the module guard before the transaction guard, which matters here:
+      // once the transaction guard is live, `setModuleGuard` is itself a guarded self-call needing
+      // a configured policy, which this fixture does not install.
+      await enableGuard({ owner, safe, safePolicyGuard, configurations: cfgs, moduleGuard: true })
     }
 
     /** A root the owners have requested and matured, ready to apply. */

--- a/test/moduleContext.spec.ts
+++ b/test/moduleContext.spec.ts
@@ -1,6 +1,6 @@
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import { expect } from 'chai'
-import { ZeroAddress } from 'ethers'
+import { Signer, ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
 import {
@@ -9,11 +9,14 @@ import {
   buildSafeTransaction,
   createConfiguration,
   createSafe,
+  enableGuard,
+  encodeModuleConfig,
   encodeMultiSend,
   execTransaction,
   randomAddress,
   safeSignTypedData
 } from '../src/utils'
+import { Safe, SafePolicyGuard } from '../typechain-types'
 import { deployAllowedModulePolicy, deployMultiSendPolicy, deploySafeContracts, deploySafePolicyGuard } from './deploy'
 
 /**
@@ -57,49 +60,24 @@ describe('Authenticated module parameter', function () {
   }
 
   /**
-   * Configures `AllowedModulePolicy` as the CALL fallback for `safe` (so it is reached by owner
-   * transactions as well as module ones), enables the module, then installs both guards.
+   * Builds the `AllowedModulePolicy` CALL-fallback configuration -- the part `enableGuard` does not
+   * cover -- so the policy is reached by owner transactions as well as module ones, then hands the
+   * module and both guards to `enableGuard`.
    */
   async function hardenWithModuleFallback(
-    owner: any,
-    safe: any,
-    safePolicyGuard: any,
+    owner: Signer,
+    safe: Safe,
+    safePolicyGuard: SafePolicyGuard,
     policyAddress: string,
     moduleAddress: string
   ) {
-    const guardAddress = await safePolicyGuard.getAddress()
-    const safeAddress = await safe.getAddress()
-
-    await execTransaction({
-      owners: [owner],
+    await enableGuard({
+      owner,
       safe,
-      to: guardAddress,
-      data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
-        [
-          createConfiguration({
-            policy: policyAddress,
-            data: ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [moduleAddress, true])
-          })
-        ]
-      ])
-    })
-    await execTransaction({
-      owners: [owner],
-      safe,
-      to: safeAddress,
-      data: safe.interface.encodeFunctionData('enableModule', [moduleAddress])
-    })
-    await execTransaction({
-      owners: [owner],
-      safe,
-      to: safeAddress,
-      data: safe.interface.encodeFunctionData('setModuleGuard', [guardAddress])
-    })
-    await execTransaction({
-      owners: [owner],
-      safe,
-      to: safeAddress,
-      data: safe.interface.encodeFunctionData('setGuard', [guardAddress])
+      safePolicyGuard,
+      configurations: [createConfiguration({ policy: policyAddress, data: encodeModuleConfig(moduleAddress) })],
+      module: moduleAddress,
+      moduleGuard: true
     })
   }
 
@@ -236,7 +214,7 @@ describe('Authenticated module parameter', function () {
             createConfiguration({
               target: subTarget,
               policy: await allowedModulePolicy.getAddress(),
-              data: ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [moduleAddress, true])
+              data: encodeModuleConfig(moduleAddress)
             })
           ]
         ])
@@ -279,7 +257,7 @@ describe('Authenticated module parameter', function () {
             [
               createConfiguration({
                 policy: await allowedModulePolicy.getAddress(),
-                data: ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [ZeroAddress, true])
+                data: encodeModuleConfig(ZeroAddress)
               })
             ]
           ])


### PR DESCRIPTION
Give each policy's configuration shape a single home in `src/utils.ts`, and replace the per-file guard-enabling harnesses with one helper.

## Context and Motivation

Reviewer feedback on #70: the local `encode(module, allowed)` helper added there "could be a utility which can be used by other tests as well". It is one of 44 hand-rolled `AbiCoder` encodings across 7 spec files, none of which share a definition of any policy's config shape — which is why #70's change to `AllowedModulePolicy.configure` had to touch three files.

The same duplication exists one level up: three identically-shaped harnesses under different names (`hardenWithModuleFallback`, `configureAndEnableGuard`, `enableGuardWithPolicy`) sit on top of 62 `configureImmediately` and 55 `setGuard`/`setModuleGuard` call sites across all 14 specs.

Note the suite already runs in ~1s, so this is about size and maintainability, not speed.

## Decisions and Tradeoffs

- Helpers land in the same PR as their first real consumers rather than as a utils-only change. An encoder with no call site is a claim rather than a fact: nothing proves `(address,bool)` is what the contract actually decodes until a test round-trips it. The remaining encoders arrive with the specs that use them.
- `enableGuard`'s step order is load-bearing and documented: configure, enable module, module guard, transaction guard. `configureImmediately` is rejected once either guard is installed, and once the transaction guard is live `setModuleGuard` is itself a guarded self-call needing a configured policy.
- `moduleConfigurationBlocked.spec.ts` is #74's security test, so it was migrated conservatively — `configurePolicies` delegates to `enableGuard` and the fixture's existing `enableModule` step is left alone. The comment explaining the module-guard-first ordering is carried across, since that is easy to "tidy" into a bug later.
- `hardenWithModuleFallback` stays as a small wrapper over `enableGuard`: it builds the `AllowedModulePolicy` CALL-fallback configuration the helper does not cover, so inlining it would repeat that construction at four call sites. Its parameters are typed rather than `any`.
- `enableGuard`'s `module` is typed `string`, not `AddressLike`. `AbiCoder` and `encodeFunctionData` are synchronous and cannot resolve a signer or a promise, so `AddressLike` would type-check and then fail at run time.
- Two module-guard-without-transaction-guard sites in `allowedModulePolicy.spec.ts` are left inline, since `enableGuard` always installs the transaction guard.
- The one remaining ad-hoc encoding in `moduleContext.spec.ts` is deliberate: it builds the *forged context payload* for the H-1 regression test, not policy configuration, and routing it through a config helper would misrepresent it.

## Testing

Suite 120 passing, unchanged; lint green. Ad-hoc encodings in the three migrated specs drop from 13 to 1.

This also fixes `npm run build:ts:typecheck`, which was already failing on `main`: `configurePolicies(cfgs: unknown[])` in `moduleConfigurationBlocked.spec.ts` made TypeScript select the wrong `encodeFunctionData` overload. It went unnoticed because CI runs lint, build and test but never the typecheck script. Fixed here because this PR could not otherwise be verified; adding the script to CI is queued for the coverage PR. The typed `enableGuard` makes that class of error impossible at the call sites it replaces.
