### PR TITLE
test: add the co-signer configuration helper

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,6 +107,14 @@ export function encodeModuleConfig(module: AddressLike, allowed = true): string 
 }
 
 /**
+ * Encodes `CoSignerPolicy` configuration data.
+ * @param cosigner The co-signer whose signature the policy will require for the access selector.
+ */
+export function encodeCoSignerConfig(cosigner: AddressLike): string {
+  return ethers.AbiCoder.defaultAbiCoder().encode(['address'], [cosigner])
+}
+
+/**
  * Appends a `SignatureExtension` envelope carrying `payload` to a Safe `signatures` blob.
  * @param signatures The owner signatures.
  * @param payload The policy context to carry in the tail.

--- a/test/coSignerPolicy.spec.ts
+++ b/test/coSignerPolicy.spec.ts
@@ -6,6 +6,7 @@ import { ethers } from 'hardhat'
 import {
   createConfiguration,
   createSafe,
+  encodeCoSignerConfig,
   execTransaction,
   safeSignTypedData,
   TransactionParametersWithNonce
@@ -60,7 +61,7 @@ describe('CoSignerPolicy', function () {
         createConfiguration({
           target: await recipient.getAddress(),
           policy: await coSignerPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [await cosigner.getAddress()])
+          data: encodeCoSignerConfig(await cosigner.getAddress())
         })
       ]
 
@@ -129,7 +130,7 @@ describe('CoSignerPolicy', function () {
           target: await recipient.getAddress(),
           selector: '0x00000000',
           policy: await coSignerPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [await cosigner.getAddress()])
+          data: encodeCoSignerConfig(await cosigner.getAddress())
         })
       ]
 
@@ -174,7 +175,7 @@ describe('CoSignerPolicy', function () {
           target: await recipient.getAddress(),
           selector: '0x00000000',
           policy: await coSignerPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [await cosigner.getAddress()])
+          data: encodeCoSignerConfig(await cosigner.getAddress())
         })
       ]
 
@@ -235,12 +236,12 @@ describe('CoSignerPolicy', function () {
         createConfiguration({
           target: await recipient.getAddress(),
           policy: await coSignerPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [await cosigner.getAddress()])
+          data: encodeCoSignerConfig(await cosigner.getAddress())
         }),
         createConfiguration({
           target: await other.getAddress(),
           policy: await coSignerPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [await other.getAddress()])
+          data: encodeCoSignerConfig(await other.getAddress())
         })
       ]
 

--- a/test/multiSendPolicy.spec.ts
+++ b/test/multiSendPolicy.spec.ts
@@ -6,6 +6,7 @@ import { ethers } from 'hardhat'
 import {
   createConfiguration,
   createSafe,
+  encodeCoSignerConfig,
   execTransaction,
   safeSignTypedData,
   randomAddress,
@@ -514,20 +515,20 @@ describe('MultiSendPolicy', function () {
         createConfiguration({
           target: await recipient.getAddress(),
           policy: await coSignerPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [await cosigner.getAddress()])
+          data: encodeCoSignerConfig(await cosigner.getAddress())
         }),
         // Configure policy for ETH transfer to other with other as cosigner
         createConfiguration({
           target: await other.getAddress(),
           policy: await coSignerPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [await other.getAddress()])
+          data: encodeCoSignerConfig(await other.getAddress())
         }),
         // Configure policy for ERC20 transfer with cosigner
         createConfiguration({
           target: await token.getAddress(),
           selector: transferSelector,
           policy: await coSignerPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['address'], [await cosigner.getAddress()])
+          data: encodeCoSignerConfig(await cosigner.getAddress())
         }),
         // Configure policy for MultiSend
         createConfiguration({


### PR DESCRIPTION
Give `CoSignerPolicy`'s configuration shape a single home, alongside the two specs that use it.

## Context and Motivation

Continues the extraction started in the previous PR. `CoSignerPolicy.configure` decodes a bare `(address)`, hand-encoded at eight call sites across `coSignerPolicy.spec.ts` and `multiSendPolicy.spec.ts`.

## Decisions and Tradeoffs

- The encoder lands with both of its consumers rather than on its own, so a reviewer can see the encoding round-trip through `CoSignerPolicy.configure` rather than take the shape on trust.
- The substitution matched only the exact `encode(['address'], [await X.getAddress()])` pattern, so it is provably limited to co-signer configuration data. Both specs contain other single-address encodings in different shapes, which are deliberately untouched.
- These two specs keep their inline `configureImmediately`/`setGuard` boilerplate for now; that moves onto `enableGuard` with the remaining specs in a later PR, to keep each diff reviewable.

## Testing

Suite 120 passing, unchanged; lint and typecheck green. Both migrated specs now contain zero ad-hoc `AbiCoder` encodings. The co-signer negative tests — wrong co-signer, missing signature — still pass, which is what demonstrates the encoding still round-trips.
