### PR TITLE
test: add the ERC-20 allowlist configuration helper

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,8 +101,10 @@ export const POLICY_CONTEXT_TYPE_HASH = ethers.id('SafePolicyGuard.PolicyContext
  * @param allowed Whether the module is allowed; pass `false` to revoke.
  * @dev Each policy's configuration shape lives in exactly one place here, so a change to a policy's
  *      `configure` signature is a one-line change in the tests rather than a hunt through the suite.
+ * @dev The encoders take resolved address strings rather than `AddressLike`, since `AbiCoder` is
+ *      synchronous and cannot resolve a signer or a promise.
  */
-export function encodeModuleConfig(module: AddressLike, allowed = true): string {
+export function encodeModuleConfig(module: string, allowed = true): string {
   return ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bool'], [module, allowed])
 }
 
@@ -110,8 +112,24 @@ export function encodeModuleConfig(module: AddressLike, allowed = true): string 
  * Encodes `CoSignerPolicy` configuration data.
  * @param cosigner The co-signer whose signature the policy will require for the access selector.
  */
-export function encodeCoSignerConfig(cosigner: AddressLike): string {
+export function encodeCoSignerConfig(cosigner: string): string {
   return ethers.AbiCoder.defaultAbiCoder().encode(['address'], [cosigner])
+}
+
+/**
+ * Encodes `ERC20ApprovePolicy` and `ERC20TransferPolicy` configuration data.
+ * @param accounts The accounts to grant or revoke -- spenders for `ERC20ApprovePolicy`, recipients
+ *        for `ERC20TransferPolicy`. An empty list configures the access selector without allowing
+ *        anyone.
+ * @param allowed Whether the accounts are allowed; pass `false` to revoke.
+ * @dev Both policies take an `(address, bool)` array (`SpenderData` and `RecipientData`), so one
+ *      encoder serves both.
+ */
+export function encodeAllowlistConfig(accounts: string[], allowed = true): string {
+  return ethers.AbiCoder.defaultAbiCoder().encode(
+    ['tuple(address account, bool allowed)[]'],
+    [accounts.map((account) => ({ account, allowed }))]
+  )
 }
 
 /**
@@ -455,7 +473,7 @@ export async function enableGuard({
  * Function to create a random address.
  * @returns A random address.
  */
-export function randomAddress(): AddressLike {
+export function randomAddress(): string {
   return ethers.getAddress(ethers.hexlify(ethers.randomBytes(20)))
 }
 
@@ -477,10 +495,10 @@ export function randomSelector(): BytesLike {
  * @returns The configuration object.
  */
 export function createConfiguration({
-  target = ZeroAddress as AddressLike,
+  target = ZeroAddress,
   selector = '0x00000000' as BytesLike,
   operation = SafeOperation.Call,
-  policy = ZeroAddress as AddressLike,
+  policy = ZeroAddress,
   data = '0x' as BytesLike
 }): SafePolicyGuard.ConfigurationStruct {
   return {

--- a/test/erc20ApprovePolicy.spec.ts
+++ b/test/erc20ApprovePolicy.spec.ts
@@ -3,7 +3,14 @@ import { expect } from 'chai'
 import { ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { createConfiguration, createSafe, execTransaction, randomAddress, SafeOperation } from '../src/utils'
+import {
+  createConfiguration,
+  createSafe,
+  encodeAllowlistConfig,
+  execTransaction,
+  randomAddress,
+  SafeOperation
+} from '../src/utils'
 import { deploySafeContracts, deploySafePolicyGuard, deployERC20ApprovePolicy, deployTestERC20Token } from './deploy'
 
 describe('ERC20ApprovePolicy', function () {
@@ -48,19 +55,12 @@ describe('ERC20ApprovePolicy', function () {
       const amount = ethers.parseEther('100')
 
       // Configure the ERC20 approve policy
-      const spenderData = [
-        {
-          spender,
-          allowed: true
-        }
-      ]
-
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('approve').selector,
           policy: await erc20ApprovePolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData])
+          data: encodeAllowlistConfig([spender])
         })
       ]
 
@@ -102,14 +102,12 @@ describe('ERC20ApprovePolicy', function () {
       const amount = ethers.parseEther('100')
 
       // Configure the ERC20 approve policy with no spender
-      const spenderData: { spender: string; allowed: boolean }[] = []
-
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('approve').selector,
           policy: await erc20ApprovePolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData])
+          data: encodeAllowlistConfig([])
         })
       ]
 
@@ -152,19 +150,12 @@ describe('ERC20ApprovePolicy', function () {
       const amount = ethers.parseEther('100')
 
       // Configure the ERC20 approve policy
-      const spenderData = [
-        {
-          spender,
-          allowed: true
-        }
-      ]
-
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('approve').selector,
           policy: await erc20ApprovePolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData])
+          data: encodeAllowlistConfig([spender])
         })
       ]
 
@@ -202,14 +193,12 @@ describe('ERC20ApprovePolicy', function () {
       const amount = ethers.parseEther('1')
 
       // Configure the ERC20 approve policy with no spender
-      const spenderData: { spender: string; allowed: boolean }[] = []
-
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('approve').selector,
           policy: await erc20ApprovePolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData])
+          data: encodeAllowlistConfig([])
         })
       ]
 
@@ -256,21 +245,13 @@ describe('ERC20ApprovePolicy', function () {
     it('Should only be able to configure ERC20 approve transactions', async function () {
       const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
 
-      // Configure the ERC20 approve policy
-      const spenderData = [
-        {
-          spender: randomAddress(),
-          allowed: true
-        }
-      ]
-
       // Trying to configure a non-approve transaction
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('transfer').selector, // Non-approve function
           policy: await erc20ApprovePolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData])
+          data: encodeAllowlistConfig([randomAddress()])
         })
       ]
 
@@ -288,21 +269,13 @@ describe('ERC20ApprovePolicy', function () {
     it('Should only be able to configure CALL operations', async function () {
       const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
 
-      // Configure the ERC20 approve policy
-      const spenderData = [
-        {
-          spender: randomAddress(),
-          allowed: true
-        }
-      ]
-
-      // Trying to configure a non-approve transaction
+      // Trying to configure a DELEGATECALL operation
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('approve').selector,
           policy: await erc20ApprovePolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address spender, bool allowed)[]'], [spenderData]),
+          data: encodeAllowlistConfig([randomAddress()]),
           operation: SafeOperation.DelegateCall // Non-CALL operation
         })
       ]

--- a/test/erc20TransferPolicy.spec.ts
+++ b/test/erc20TransferPolicy.spec.ts
@@ -3,7 +3,14 @@ import { expect } from 'chai'
 import { ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { createConfiguration, createSafe, execTransaction, randomAddress, SafeOperation } from '../src/utils'
+import {
+  createConfiguration,
+  createSafe,
+  encodeAllowlistConfig,
+  execTransaction,
+  randomAddress,
+  SafeOperation
+} from '../src/utils'
 import { deploySafeContracts, deploySafePolicyGuard, deployERC20TransferPolicy, deployTestERC20Token } from './deploy'
 
 describe('ERC20TransferPolicy', function () {
@@ -56,19 +63,12 @@ describe('ERC20TransferPolicy', function () {
       const amount = ethers.parseEther('100')
 
       // Configure the ERC20 transfer policy
-      const recipientData = [
-        {
-          recipient: await recipient.getAddress(),
-          allowed: true
-        }
-      ]
-
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('transfer').selector,
           policy: await erc20TransferPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+          data: encodeAllowlistConfig([await recipient.getAddress()])
         })
       ]
 
@@ -106,14 +106,12 @@ describe('ERC20TransferPolicy', function () {
       const amount = ethers.parseEther('100')
 
       // Configure the ERC20 transfer policy with no recipients
-      const recipientData: { recipient: string; allowed: boolean }[] = []
-
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('transfer').selector,
           policy: await erc20TransferPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+          data: encodeAllowlistConfig([])
         })
       ]
 
@@ -155,19 +153,12 @@ describe('ERC20TransferPolicy', function () {
       const amount = ethers.parseEther('100')
 
       // Configure the ERC20 transfer policy
-      const recipientData = [
-        {
-          recipient: await recipient.getAddress(),
-          allowed: true
-        }
-      ]
-
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('transfer').selector,
           policy: await erc20TransferPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+          data: encodeAllowlistConfig([await recipient.getAddress()])
         })
       ]
 
@@ -207,19 +198,12 @@ describe('ERC20TransferPolicy', function () {
       await token.mint(await owner.getAddress(), amount)
 
       // Configure the ERC20 transfer policy
-      const recipientData = [
-        {
-          recipient: await recipient.getAddress(),
-          allowed: true
-        }
-      ]
-
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('transferFrom').selector,
           policy: await erc20TransferPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+          data: encodeAllowlistConfig([await recipient.getAddress()])
         })
       ]
 
@@ -263,21 +247,13 @@ describe('ERC20TransferPolicy', function () {
     it('Should only be able to configure ERC20 transfer transactions', async function () {
       const { owner, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
 
-      // Configure the ERC20 transfer policy
-      const recipientData = [
-        {
-          recipient: randomAddress(),
-          allowed: true
-        }
-      ]
-
       // Trying to configure a non-transfer transaction
       const configurations = [
         createConfiguration({
           target: await token.getAddress(),
           selector: token.interface.getFunction('approve').selector, // Non-transfer function
           policy: await erc20TransferPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+          data: encodeAllowlistConfig([randomAddress()])
         })
       ]
 
@@ -295,14 +271,6 @@ describe('ERC20TransferPolicy', function () {
     it('Should only allow CALL operations', async function () {
       const { owner, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
 
-      // Configure the ERC20 transfer policy
-      const recipientData = [
-        {
-          recipient: randomAddress(),
-          allowed: true
-        }
-      ]
-
       // Trying to configure with DELEGATECALL operation
       const configurations = [
         createConfiguration({
@@ -310,7 +278,7 @@ describe('ERC20TransferPolicy', function () {
           selector: token.interface.getFunction('transfer').selector,
           operation: SafeOperation.DelegateCall,
           policy: await erc20TransferPolicy.getAddress(),
-          data: ethers.AbiCoder.defaultAbiCoder().encode(['tuple(address recipient, bool allowed)[]'], [recipientData])
+          data: encodeAllowlistConfig([randomAddress()])
         })
       ]
 
@@ -337,12 +305,7 @@ describe('ERC20TransferPolicy', function () {
       )
 
       // Configure with empty recipient list
-      const emptyRecipientData = ethers.AbiCoder.defaultAbiCoder().encode(
-        ['tuple(address recipient, bool allowed)[]'],
-        [[]]
-      )
-
-      await expect(erc20TransferPolicy.configure(ZeroAddress, access, emptyRecipientData)).to.not.be.reverted
+      await expect(erc20TransferPolicy.configure(ZeroAddress, access, encodeAllowlistConfig([]))).to.not.be.reverted
     })
 
     it('Should handle recipient permission toggle', async function () {
@@ -358,36 +321,13 @@ describe('ERC20TransferPolicy', function () {
       )
 
       // First, allow the recipient
-      const allowRecipientData = ethers.AbiCoder.defaultAbiCoder().encode(
-        ['tuple(address recipient, bool allowed)[]'],
-        [
-          [
-            {
-              recipient: recipientAddress,
-              allowed: true
-            }
-          ]
-        ]
-      )
-
-      await erc20TransferPolicy.configure(ZeroAddress, access, allowRecipientData)
+      await erc20TransferPolicy.configure(ZeroAddress, access, encodeAllowlistConfig([recipientAddress]))
       expect(await erc20TransferPolicy.isRecipientAllowed(deployer, ZeroAddress, tokenAddress, recipientAddress)).to.be
         .true
 
       // Then, disallow the same recipient
-      const disallowRecipientData = ethers.AbiCoder.defaultAbiCoder().encode(
-        ['tuple(address recipient, bool allowed)[]'],
-        [
-          [
-            {
-              recipient: recipientAddress,
-              allowed: false
-            }
-          ]
-        ]
-      )
-
-      await expect(erc20TransferPolicy.configure(ZeroAddress, access, disallowRecipientData)).to.not.be.reverted
+      await expect(erc20TransferPolicy.configure(ZeroAddress, access, encodeAllowlistConfig([recipientAddress], false)))
+        .to.not.be.reverted
       expect(await erc20TransferPolicy.isRecipientAllowed(deployer, ZeroAddress, tokenAddress, recipientAddress)).to.be
         .false
     })


### PR DESCRIPTION
Give both ERC-20 policies' configuration shape a single home, alongside the two specs that use it.

## Context and Motivation

`ERC20ApprovePolicy.SpenderData` and `ERC20TransferPolicy.RecipientData` are both `(address, bool)`, hand-encoded at fifteen call sites across `erc20ApprovePolicy.spec.ts` and `erc20TransferPolicy.spec.ts`. The differing tuple field name is cosmetic to the ABI encoding, so one encoder serves both policies.

## Decisions and Tradeoffs

- A single `encodeAllowlistConfig` rather than a spender encoder and a recipient encoder converging on one implementation: two names for one encoding buys nothing at the call site.
- The encoder lands with both of its consumers rather than on its own, so a reviewer can see the encoding round-trip through each policy's `configure` rather than take the shape on trust.
- The encoders' address parameters narrow from `AddressLike` to `string`, and `randomAddress` narrows its return type to match. `AbiCoder` is synchronous and cannot resolve a signer or a promise, so `AddressLike` admitted values that type-check and then fail at run time with `invalid address` -- hit while writing this PR. `encodeModuleConfig` and `encodeCoSignerConfig` carried the same latent trap and are narrowed too. `createConfiguration`'s `target` and `policy` narrow with them: every consumer of a `Configuration` in this repo is synchronous -- `getConfigurationRoot` feeds `AbiCoder.encode`, and configuration is submitted via `encodeFunctionData` -- so neither resolves an `AddressLike` either. `AddressLike` remains correct only where a value reaches a contract method call, which ethers does resolve.
- These two specs keep their inline `configureImmediately`/`setGuard` boilerplate for now; that moves onto `enableGuard` with the remaining specs in a later PR, to keep each diff reviewable.

## Testing

Suite 120 passing, unchanged; lint and typecheck green. Both migrated specs now contain zero ad-hoc `AbiCoder` encodings. The new encoding was confirmed byte-identical to every expression it replaced -- single-allowed, revoke and empty-list -- so no test can pass for a changed reason. The narrowed type was confirmed to reject a signer at compile time by temporarily reintroducing one.

One comment is corrected alongside: an `ERC20ApprovePolicy` configuration test was labelled "Trying to configure a non-approve transaction" where it configures a DELEGATECALL operation.