### PR TITLE
test: adopt the enableGuard helper in the policy specs

### DIFF
--- a/test/allowPolicy.spec.ts
+++ b/test/allowPolicy.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { createConfiguration, createSafe, execTransaction, randomAddress } from '../src/utils'
+import { createConfiguration, createSafe, enableGuard, execTransaction, randomAddress } from '../src/utils'
 import { deploySafePolicyGuard, deploySafeContracts, deployAllowPolicy } from './deploy'
 
 describe('AllowPolicy', function () {
@@ -40,22 +40,12 @@ describe('AllowPolicy', function () {
       const target = randomAddress()
       const value = ethers.parseEther('1')
 
-      const configurations = [createConfiguration({ target, policy: await allowPolicy.getAddress() })]
-
-      // Configure the allow policy to send some value to the target
-      await execTransaction({
-        owners: [owner],
+      // Configure the allow policy to send some value to the target, then enable the guard
+      await enableGuard({
+        owner,
         safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+        safePolicyGuard,
+        configurations: [createConfiguration({ target, policy: await allowPolicy.getAddress() })]
       })
 
       // Send some ETH from owner to the safe for next transaction
@@ -82,13 +72,8 @@ describe('AllowPolicy', function () {
       const target = randomAddress()
       const value = ethers.parseEther('1')
 
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Enable the guard on safe, with nothing configured
+      await enableGuard({ owner, safe, safePolicyGuard })
 
       // Try to execute a random transaction
       await expect(

--- a/test/denyPolicy.spec.ts
+++ b/test/denyPolicy.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { createConfiguration, createSafe, execTransaction, randomAddress } from '../src/utils'
+import { createConfiguration, createSafe, enableGuard, execTransaction, randomAddress } from '../src/utils'
 import { deploySafePolicyGuard, deploySafeContracts, deployAllowPolicy, deployDenyPolicy } from './deploy'
 
 describe('DenyPolicy', function () {
@@ -50,22 +50,12 @@ describe('DenyPolicy', function () {
       const target = randomAddress()
       const value = ethers.parseEther('1')
 
-      const configurations = [createConfiguration({ target, policy: await denyPolicy.getAddress() })]
-
-      // Configure the deny policy to send some value to the target
-      await execTransaction({
-        owners: [owner],
+      // Configure the deny policy for the target, then enable the guard
+      await enableGuard({
+        owner,
         safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+        safePolicyGuard,
+        configurations: [createConfiguration({ target, policy: await denyPolicy.getAddress() })]
       })
 
       // Send some ETH from owner to the safe for next transaction

--- a/test/nativeTransferPolicy.spec.ts
+++ b/test/nativeTransferPolicy.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { createConfiguration, createSafe, execTransaction, SafeOperation } from '../src/utils'
+import { createConfiguration, createSafe, enableGuard, execTransaction, SafeOperation } from '../src/utils'
 import { deploySafeContracts, deploySafePolicyGuard, deployNativeTransferPolicy } from './deploy'
 
 describe('NativeTransferPolicy', function () {
@@ -48,27 +48,12 @@ describe('NativeTransferPolicy', function () {
 
       const amount = ethers.parseEther('1')
 
-      // Configure the native transfer policy
-      const configurations = [
-        createConfiguration({
-          policy: await nativeTransferPolicy.getAddress()
-        })
-      ]
-
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
+      // Configure the native transfer policy as the fallback, then enable the guard
+      await enableGuard({
+        owner,
         safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+        safePolicyGuard,
+        configurations: [createConfiguration({ policy: await nativeTransferPolicy.getAddress() })]
       })
 
       // Get initial balances
@@ -94,27 +79,12 @@ describe('NativeTransferPolicy', function () {
     it('Should not allow native transfer with value = 0', async function () {
       const { owner, recipient, safePolicyGuard, safe, nativeTransferPolicy } = await loadFixture(fixture)
 
-      // Configure the native transfer policy
-      const configurations = [
-        createConfiguration({
-          policy: await nativeTransferPolicy.getAddress()
-        })
-      ]
-
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
+      // Configure the native transfer policy as the fallback, then enable the guard
+      await enableGuard({
+        owner,
         safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+        safePolicyGuard,
+        configurations: [createConfiguration({ policy: await nativeTransferPolicy.getAddress() })]
       })
 
       // Try to execute a native transfer transaction with zero value (Default value is 0)
@@ -137,27 +107,12 @@ describe('NativeTransferPolicy', function () {
 
       const amount = ethers.parseEther('1')
 
-      // Configure the native transfer policy
-      const configurations = [
-        createConfiguration({
-          policy: await nativeTransferPolicy.getAddress()
-        })
-      ]
-
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
+      // Configure the native transfer policy as the fallback, then enable the guard
+      await enableGuard({
+        owner,
         safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+        safePolicyGuard,
+        configurations: [createConfiguration({ policy: await nativeTransferPolicy.getAddress() })]
       })
 
       // Try to execute a transaction with data (non-native transfer)

--- a/test/policyEngine.spec.ts
+++ b/test/policyEngine.spec.ts
@@ -6,6 +6,7 @@ import { ethers } from 'hardhat'
 import {
   createSafe,
   SafeOperation,
+  enableGuard,
   execTransaction,
   randomAddress,
   randomSelector,
@@ -227,22 +228,14 @@ describe('PolicyEngine Edge Cases', function () {
       // The fallback denies (MockPolicy returns a zero magic value) and the exact match allows, so
       // a success can only mean the exact match was selected.
       await mockPolicy.setRevertTransaction(true)
-      await execTransaction({
-        owners: [owner],
+      await enableGuard({
+        owner,
         safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
-          [
-            createConfiguration({ policy: await mockPolicy.getAddress() }),
-            createConfiguration({ target, policy: await allowPolicy.getAddress() })
-          ]
-        ])
-      })
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({ policy: await mockPolicy.getAddress() }),
+          createConfiguration({ target, policy: await allowPolicy.getAddress() })
+        ]
       })
 
       await expect(execTransaction({ owners: [owner], safe, to: target })).to.not.be.reverted
@@ -258,19 +251,13 @@ describe('PolicyEngine Edge Cases', function () {
       const { allowPolicy } = await deployAllowPolicy()
 
       // The operation is part of the access selector, so the two fallbacks are separate keys.
-      await execTransaction({
-        owners: [owner],
+      await enableGuard({
+        owner,
         safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
-          [createConfiguration({ operation: SafeOperation.DelegateCall, policy: await allowPolicy.getAddress() })]
-        ])
-      })
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({ operation: SafeOperation.DelegateCall, policy: await allowPolicy.getAddress() })
+        ]
       })
 
       await expect(execTransaction({ owners: [owner], safe, to: randomAddress() }))
@@ -285,19 +272,11 @@ describe('PolicyEngine Edge Cases', function () {
       const { owner, safe, safePolicyGuard, mockPolicy } = base
       const target = randomAddress()
 
-      await execTransaction({
-        owners: [owner],
+      await enableGuard({
+        owner,
         safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
-          [createConfiguration({ target, policy: await mockPolicy.getAddress() })]
-        ])
-      })
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+        safePolicyGuard,
+        configurations: [createConfiguration({ target, policy: await mockPolicy.getAddress() })]
       })
 
       return { ...base, target }

--- a/test/reentrancy.spec.ts
+++ b/test/reentrancy.spec.ts
@@ -7,6 +7,7 @@ import {
   SafeOperation,
   createConfiguration,
   createSafe,
+  enableGuard,
   execTransaction,
   getConfigurationRoot,
   getSafeTransactionHash,
@@ -52,31 +53,17 @@ describe('Non-view check path — reentrancy & Safe confinement', function () {
     return { ownerA, ownerB, safePolicyGuard, safeA, safeB }
   }
 
-  // Configures `policy` for `owner`'s Safe (via configureImmediately) using the given
-  // configuration overrides, then enables the guard on that Safe.
-  async function configureAndEnableGuard(owner: any, safe: any, safePolicyGuard: any, configurations: any[]) {
-    await execTransaction({
-      owners: [owner],
-      safe,
-      to: await safePolicyGuard.getAddress(),
-      data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-    })
-    await execTransaction({
-      owners: [owner],
-      safe,
-      to: await safe.getAddress(),
-      data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-    })
-  }
-
   it('Should block a policy re-entering the guard during a check (Reentrancy)', async function () {
     const { ownerA, safePolicyGuard, safeA } = await loadFixture(fixture)
 
     const x = await deployReentrantPolicy()
     await x.setMode(Mode.ReenterGuardEntry)
-    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
-      createConfiguration({ policy: await x.getAddress() })
-    ])
+    await enableGuard({
+      owner: ownerA,
+      safe: safeA,
+      safePolicyGuard,
+      configurations: [createConfiguration({ policy: await x.getAddress() })]
+    })
 
     // Outer tx succeeds: the policy catches the (blocked) reentry and returns the magic value.
     await execTransaction({ owners: [ownerA], safe: safeA, to: randomAddress() })
@@ -104,9 +91,12 @@ describe('Non-view check path — reentrancy & Safe confinement', function () {
     const policyX = await deployReentrantPolicy()
     await policyX.setMode(Mode.ReenterEngine)
     await policyX.setReenter(await safeB.getAddress(), randomAddress())
-    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
-      createConfiguration({ policy: await policyX.getAddress() })
-    ])
+    await enableGuard({
+      owner: ownerA,
+      safe: safeA,
+      safePolicyGuard,
+      configurations: [createConfiguration({ policy: await policyX.getAddress() })]
+    })
 
     // Safe A executes; X tries to drive a check for Safe B mid-check.
     await execTransaction({ owners: [ownerA], safe: safeA, to: randomAddress() })
@@ -133,10 +123,15 @@ describe('Non-view check path — reentrancy & Safe confinement', function () {
     await policyX.setMode(Mode.ReenterEngine)
     await policyX.setReenter(await safeA.getAddress(), targetZ)
 
-    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
-      createConfiguration({ target: targetX, policy: await policyX.getAddress() }),
-      createConfiguration({ target: targetZ, policy: await policyZ.getAddress() })
-    ])
+    await enableGuard({
+      owner: ownerA,
+      safe: safeA,
+      safePolicyGuard,
+      configurations: [
+        createConfiguration({ target: targetX, policy: await policyX.getAddress() }),
+        createConfiguration({ target: targetZ, policy: await policyZ.getAddress() })
+      ]
+    })
 
     // Safe A executes a tx to targetX -> X -> re-enters the engine for A/targetZ -> Z.
     await execTransaction({ owners: [ownerA], safe: safeA, to: targetX })
@@ -151,9 +146,12 @@ describe('Non-view check path — reentrancy & Safe confinement', function () {
 
     const policy = await deployReentrantPolicy()
     await policy.setMode(Mode.WriteState)
-    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
-      createConfiguration({ policy: await policy.getAddress() })
-    ])
+    await enableGuard({
+      owner: ownerA,
+      safe: safeA,
+      safePolicyGuard,
+      configurations: [createConfiguration({ policy: await policy.getAddress() })]
+    })
 
     expect(await policy.writes()).to.equal(0n)
     await execTransaction({ owners: [ownerA], safe: safeA, to: randomAddress() })
@@ -166,9 +164,12 @@ describe('Non-view check path — reentrancy & Safe confinement', function () {
     // The counterpart of the transaction-guard case above: both entry points call `_enterCheck`.
     const policy = await deployReentrantPolicy()
     await policy.setMode(Mode.ReenterModuleGuardEntry)
-    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
-      createConfiguration({ policy: await policy.getAddress() })
-    ])
+    await enableGuard({
+      owner: ownerA,
+      safe: safeA,
+      safePolicyGuard,
+      configurations: [createConfiguration({ policy: await policy.getAddress() })]
+    })
 
     await execTransaction({ owners: [ownerA], safe: safeA, to: randomAddress() })
 
@@ -211,16 +212,24 @@ describe('Non-view check path — reentrancy & Safe confinement', function () {
     const { allowPolicy } = await deployAllowPolicy()
 
     const innerTarget = randomAddress()
-    await configureAndEnableGuard(ownerB, safeB, safePolicyGuard, [
-      createConfiguration({ target: innerTarget, policy: await allowPolicy.getAddress() })
-    ])
-    await configureAndEnableGuard(ownerA, safeA, safePolicyGuard, [
-      createConfiguration({
-        target: await safeB.getAddress(),
-        selector: safeB.interface.getFunction('execTransaction')?.selector,
-        policy: await allowPolicy.getAddress()
-      })
-    ])
+    await enableGuard({
+      owner: ownerB,
+      safe: safeB,
+      safePolicyGuard,
+      configurations: [createConfiguration({ target: innerTarget, policy: await allowPolicy.getAddress() })]
+    })
+    await enableGuard({
+      owner: ownerA,
+      safe: safeA,
+      safePolicyGuard,
+      configurations: [
+        createConfiguration({
+          target: await safeB.getAddress(),
+          selector: safeB.interface.getFunction('execTransaction')?.selector,
+          policy: await allowPolicy.getAddress()
+        })
+      ]
+    })
 
     // Safe B's owner pre-approves the inner hash so that Safe A can be the executor.
     const innerHash = await getSafeTransactionHash({ safe: safeB, to: innerTarget })


### PR DESCRIPTION
Replace the inline `configureImmediately` + `setGuard` pairs in five specs with `enableGuard`, and delete the last positional duplicate of it.

## Context and Motivation

`enableGuard` landed in an earlier PR with the three module specs. The remaining specs still open with the same two `execTransaction` blocks, whose ordering is load-bearing: `configureImmediately` is rejected once either guard points at the policy guard, so all configuration has to happen first. Every copy of that sequence is a chance to get the order wrong.

`reentrancy.spec.ts` carried `configureAndEnableGuard`, which was byte-for-byte `enableGuard` with positional arguments. It is deleted and its seven call sites converted, rather than kept as a wrapper that only reorders arguments -- that indirection is what the review comment behind this refactor was about. `moduleContext.spec.ts` keeps its wrapper, which is not pure argument reordering: it builds the `AllowedModulePolicy` CALL-fallback configuration that `enableGuard` does not cover, and inlining it would repeat that construction at four call sites.

## Decisions and Tradeoffs

- `safePolicyGuard.spec.ts` is deferred to the next PR. It holds 37 of the call sites on its own -- more than these five specs combined -- on a 1,349-line file that a later PR splits by concern. Migrating it here would bury this diff.
- `gasBenchmark.spec.ts` is not a candidate at all. It enables the guard first and then drives the delayed `requestConfiguration`/`applyConfiguration` path, the reverse of `enableGuard`'s ordering, and it needs each transaction receipt individually to log gas usage. Routing it through the helper would change what it measures.
- Sites where the guard is deliberately left off are untouched: `denyPolicy.spec.ts`'s fixture configures a fallback and lets the test install the guard later, and `nativeTransferPolicy.spec.ts`'s two configuration tests assert that `configureImmediately` itself reverts. `enableGuard` always installs the transaction guard, so it does not fit either shape.

## Testing

Suite 120 passing, unchanged; lint and typecheck green. The migrated negative tests still fail for their original reasons -- `AccessDenied` with the zero address for an unconfigured target, `AccessDenied` naming the deny policy, `CrossSafeCheck` for the cross-Safe re-entry -- which is what shows the helper reproduces the ordering it replaced. Imports were checked for staleness after the substitution.
