### PR TITLE
chore: scope coverage to production contracts and gate typechecking in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,6 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run build
+      # Runs after the build, which generates the TypeChain types it needs.
+      - run: npm run build:ts:typecheck
       - run: npm run test

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,6 @@
+module.exports = {
+  // Test-only contracts: mocks, harnesses, and the demo-only `AppSafePolicyGuard`. Reporting on
+  // them buries the production numbers -- `AppSafePolicyGuard` alone is never exercised by the
+  // suite and drags the total down by around 15 points.
+  skipFiles: ['test/']
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,5 +53,12 @@ export default [
       '@typescript-eslint/no-shadow': 'off'
     }
   },
+  {
+    // `solidity-coverage` loads `.solcover.js` with `require`, so it has to stay CommonJS.
+    files: ['.solcover.js'],
+    languageOptions: {
+      sourceType: 'commonjs'
+    }
+  },
   { ignores: ['**/node_modules', '**/.data'] }
 ]

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:fix:ts": "eslint --fix",
     "test": "hardhat test --network hardhat",
     "test:bench": "hardhat test --grep '@bench'",
+    "coverage": "hardhat coverage",
     "verify": "hardhat etherscan-verify --force-license --license LGPL-3.0 --network"
   },
   "dependencies": {


### PR DESCRIPTION
Report coverage on the contracts that ship, and make CI run the typecheck it already had a script for.

## Context and Motivation

Reported coverage sat at 83.5%, almost entirely because `contracts/test/App/AppSafePolicyGuard.sol` is a demo-only contract the suite never exercises. That number hid the production picture: with test-only contracts skipped, the same suite covers 99.31% of statements, 94% of branches and 97.75% of lines. Without this, the figure an auditor reads understates the suite by roughly fifteen points.

Separately, `build:ts:typecheck` existed as an npm script but no CI job ran it, so a type error could land on `main` unnoticed -- and one had. That is fixed here rather than in the PR that repaired the error, so the gate and the repair are reviewable apart from each other.

## Changes

- `.solcover.js`: new, with `skipFiles: ['test/']`.
- `package.json`: add a `coverage` script.
- `.github/workflows/ci.yml`: run `build:ts:typecheck` in the `tests` job.
- `eslint.config.mjs`: treat `.solcover.js` as CommonJS.

## Decisions and Tradeoffs

- The typecheck runs in the `tests` job rather than `lint`, because `typechain-types/` is generated and gitignored, so `tsc` has nothing to resolve against until `hardhat compile` has run. The `tests` job already builds; putting it in `lint` would mean a second compile for no benefit.
- `.solcover.js` is scoped to `sourceType: 'commonjs'` in the eslint config rather than added to `ignores`. `solidity-coverage` loads it with `require`, so it cannot become ESM, but it should still be linted.
- `AppSafePolicyGuard` itself is unchanged. It is a demo subclass, `DEMO`-gated, and correctly placed under `contracts/test/`, so `skipFiles` is the right lever rather than moving or testing it. Note that `networks.json` records it on Gnosis (chain 100) as well as the two testnets, and `SafePolicyGuard` is recorded nowhere -- so the guard deployed under `DEMO` is what exists on those networks. Those deployments are demonstrations; a later commit states as much in the contract and the README.
- `hardhat coverage` does not honour the `test` script's grep, so it instruments the benchmarks too and measures a different set than `npm test` reports. The figures are unaffected -- re-running with the benchmarks excluded gives the same result -- but "the suite is N tests" and "coverage is N%" are about different runs. Coverage is measured, not gated; a CI job for it is left as a follow-up.

## Testing

Suite 120 passing, unchanged; lint and typecheck green. `npm run coverage` was run to confirm `skipFiles` takes effect and to re-measure the remaining gaps from `coverage.json`. The CI gate was confirmed to cover `test/` by temporarily adding a file there with the same type error that previously reached `main`, and checking that `tsc` failed on it.
