### PR TITLE
test: cover the remaining policy branches and document their edge cases

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,6 +1,13 @@
 module.exports = {
-  // Test-only contracts: mocks, harnesses, and the demo-only `AppSafePolicyGuard`. Reporting on
-  // them buries the production numbers -- `AppSafePolicyGuard` alone is never exercised by the
-  // suite and drags the total down by around 15 points.
-  skipFiles: ['test/']
+  skipFiles: [
+    // Test-only contracts: mocks, harnesses, and the demo-only `AppSafePolicyGuard`. Reporting on
+    // them buries the production numbers -- `AppSafePolicyGuard` alone is never exercised by the
+    // suite and drags the total down by around 15 points.
+    'test/',
+    // Vendored verbatim from `safe-research/safenet`, which owns its unit tests:
+    // `contracts/test/libraries/SignatureExtension.t.sol`. Its standalone rejection paths are
+    // covered there rather than duplicated here; this repo exercises it end-to-end through the
+    // guard's context decoding.
+    'libraries/SignatureExtension.sol'
+  ]
 }

--- a/contracts/policies/CoSignerPolicy.sol
+++ b/contracts/policies/CoSignerPolicy.sol
@@ -9,6 +9,9 @@ import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/Signa
 /**
  * @title Co-Signer Policy
  * @dev Ensure a Safe transaction has been co-signed.
+ * @dev Transaction path only: the `nonce() - 1` below assumes the nonce increment that
+ *      `execTransactionFromModule` never performs, so no co-signature can validate on the module
+ *      path. It fails closed, but do not rely on this policy to gate module transactions.
  */
 contract CoSignerPolicy is IPolicy {
     /**

--- a/contracts/policies/ERC20ApprovePolicy.sol
+++ b/contracts/policies/ERC20ApprovePolicy.sol
@@ -8,6 +8,8 @@ import {AccessSelector} from "../libraries/AccessSelector.sol";
 /**
  * @title ERC-20 Approve Policy
  * @dev Allow ERC-20 approvals only for specific spender addresses.
+ * @dev `approve(spender, 0)` is permitted for any spender, so revoking never depends on the
+ *      allowlist. Any spender's allowance can therefore be zeroed regardless of configuration.
  */
 contract ERC20ApprovePolicy is IPolicy {
     using AccessSelector for AccessSelector.T;

--- a/contracts/policies/ERC20TransferPolicy.sol
+++ b/contracts/policies/ERC20TransferPolicy.sol
@@ -8,6 +8,8 @@ import {AccessSelector} from "../libraries/AccessSelector.sol";
 /**
  * @title ERC-20 Transfer Policy
  * @dev Allow ERC-20 transfers only to a specific address list.
+ * @dev `transferFrom`'s `from` argument is deliberately unconstrained: the policy restricts where
+ *      tokens may go, not whose tokens they are.
  */
 contract ERC20TransferPolicy is IPolicy {
     using AccessSelector for AccessSelector.T;

--- a/contracts/policies/NativeTransferPolicy.sol
+++ b/contracts/policies/NativeTransferPolicy.sol
@@ -7,6 +7,9 @@ import {AccessSelector} from "../libraries/AccessSelector.sol";
 /**
  * @title Native Transfer Policy
  * @dev Allow native token transfers.
+ * @dev The recipient comes from the access selector this is configured under, so it must be
+ *      configured per target. The CALL fallback key also satisfies {configure}, where it permits any
+ *      amount to any address, `address(0)` included.
  */
 contract NativeTransferPolicy is IPolicy {
     using AccessSelector for AccessSelector.T;

--- a/contracts/test/TestNonSafeConfigurer.sol
+++ b/contracts/test/TestNonSafeConfigurer.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.28;
+
+import {SafePolicyGuard} from "../SafePolicyGuard.sol";
+
+/**
+ * @dev Has no `getStorageAt` and no fallback, so the guard's probe for an installed guard reverts
+ *      with no return data.
+ */
+contract TestNonSafeConfigurer {
+    function configure(SafePolicyGuard guard, SafePolicyGuard.Configuration[] calldata configurations) external {
+        guard.configureImmediately(configurations);
+    }
+}

--- a/contracts/test/TestRevertingStorageConfigurer.sol
+++ b/contracts/test/TestRevertingStorageConfigurer.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.28;
+
+import {SafePolicyGuard} from "../SafePolicyGuard.sol";
+
+/**
+ * @dev Reverts from `getStorageAt` with return data shaped like a successful answer, planting the
+ *      guard's own address in the word the guard reads. Only the call status distinguishes this from
+ *      a real answer.
+ */
+contract TestRevertingStorageConfigurer {
+    // solhint-disable-next-line private-vars-leading-underscore
+    address private $guard;
+
+    function configure(SafePolicyGuard guard, SafePolicyGuard.Configuration[] calldata configurations) external {
+        $guard = address(guard);
+        guard.configureImmediately(configurations);
+    }
+
+    function getStorageAt(uint256, uint256) external view {
+        address planted = $guard;
+
+        // `bytes` holding one word, as a Safe answers: 32 offset + 32 length + 32 data. Reverting
+        // with this payload makes the return data well-formed but the call unsuccessful.
+        // solhint-disable-next-line no-inline-assembly
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+            mstore(ptr, 0x20)
+            mstore(add(ptr, 0x20), 1)
+            mstore(add(ptr, 0x40), planted)
+            revert(ptr, 0x60)
+        }
+    }
+}

--- a/test/coSignerPolicy.spec.ts
+++ b/test/coSignerPolicy.spec.ts
@@ -6,16 +6,18 @@ import { ethers } from 'hardhat'
 import {
   createConfiguration,
   createSafe,
+  enableGuard,
   encodeCoSignerConfig,
   execTransaction,
   safeSignTypedData,
+  SafeOperation,
   TransactionParametersWithNonce
 } from '../src/utils'
 import { deploySafeContracts, deploySafePolicyGuard, deployCoSignerPolicy } from './deploy'
 
 describe('CoSignerPolicy', function () {
   async function fixture() {
-    const [, owner, cosigner, recipient, other] = await ethers.getSigners()
+    const [deployer, owner, cosigner, recipient, other] = await ethers.getSigners()
 
     // Deploy the SafePolicyGuard contract
     const { safePolicyGuard } = await deploySafePolicyGuard()
@@ -40,6 +42,7 @@ describe('CoSignerPolicy', function () {
     })
 
     return {
+      deployer,
       owner,
       cosigner,
       recipient,
@@ -325,6 +328,50 @@ describe('CoSignerPolicy', function () {
       expect(finalRecipientBalance - initialRecipientBalance).to.equal(amount)
       expect(finalOtherBalance - initialOtherBalance).to.equal(amount)
       expect(initialSafeBalance - finalSafeBalance).to.equal(amount * 2n)
+    })
+
+    it('Should reject a transaction when the configured co-signer is the zero address', async function () {
+      // `configure` takes whatever address it is handed, so a Safe can configure the policy with no
+      // co-signer at all. That has to fail closed at check time rather than accept any signature.
+      const { owner, recipient, safePolicyGuard, safe, coSignerPolicy } = await loadFixture(fixture)
+
+      await enableGuard({
+        owner,
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target: await recipient.getAddress(),
+            policy: await coSignerPolicy.getAddress(),
+            data: encodeCoSignerConfig(ZeroAddress)
+          })
+        ]
+      })
+
+      await expect(
+        execTransaction({ owners: [owner], safe, to: await recipient.getAddress(), value: ethers.parseEther('1') })
+      )
+        .to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+        .withArgs(
+          await coSignerPolicy.getAddress(),
+          coSignerPolicy.interface.encodeErrorResult('NoCosignerConfigured', [])
+        )
+    })
+  })
+
+  describe('getCoSigner', function () {
+    it('Should report the co-signer configured for an access selector', async function () {
+      // State is namespaced by `msg.sender`, and `getCoSigner` reads that same namespace, so
+      // configuring directly is what makes the getter observable.
+      const { deployer, cosigner, recipient, safe, coSignerPolicy } = await loadFixture(fixture)
+      const accessSelector = await (await ethers.getContractFactory('TestAccessSelector')).deploy()
+      const access = await accessSelector.create(await recipient.getAddress(), '0x00000000', SafeOperation.Call)
+
+      expect(await coSignerPolicy.connect(deployer).getCoSigner(safe, access)).to.equal(ZeroAddress)
+
+      await coSignerPolicy.connect(deployer).configure(safe, access, encodeCoSignerConfig(await cosigner.getAddress()))
+
+      expect(await coSignerPolicy.connect(deployer).getCoSigner(safe, access)).to.equal(await cosigner.getAddress())
     })
   })
 })

--- a/test/erc20ApprovePolicy.spec.ts
+++ b/test/erc20ApprovePolicy.spec.ts
@@ -290,5 +290,48 @@ describe('ERC20ApprovePolicy', function () {
         })
       ).to.be.revertedWithCustomError(erc20ApprovePolicy, 'InvalidOperation')
     })
+
+    it('Should reject calldata that is not an ERC-20 approve', async function () {
+      // `configure` pins the selector, so the engine can only route `approve` calldata here. This is
+      // the policy defending its own decode when called directly, which anyone may do.
+      const { safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      await expect(
+        erc20ApprovePolicy.checkTransaction(
+          safe,
+          token,
+          0n,
+          token.interface.encodeFunctionData('transfer', [randomAddress(), 1n]),
+          SafeOperation.Call,
+          ZeroAddress,
+          '0x',
+          0n
+        )
+      ).to.be.revertedWithCustomError(erc20ApprovePolicy, 'InvalidApproval')
+    })
+  })
+
+  describe('isSpenderAllowed', function () {
+    it('Should report whether a spender is allowed for a Safe and token', async function () {
+      // State is namespaced by `msg.sender`, which the getter takes explicitly, so configuring
+      // directly makes the deployer the namespace to query.
+      const { owner, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+      const accessSelector = await (await ethers.getContractFactory('TestAccessSelector')).deploy()
+      const access = await accessSelector.create(
+        token,
+        token.interface.getFunction('approve').selector,
+        SafeOperation.Call
+      )
+      const spender = randomAddress()
+
+      expect(await erc20ApprovePolicy.isSpenderAllowed(owner, safe, token, spender)).to.equal(false)
+
+      await erc20ApprovePolicy.connect(owner).configure(safe, access, encodeAllowlistConfig([spender]))
+      expect(await erc20ApprovePolicy.isSpenderAllowed(owner, safe, token, spender)).to.equal(true)
+
+      // The same call can revoke, which is why `configure` takes a flag per entry.
+      await erc20ApprovePolicy.connect(owner).configure(safe, access, encodeAllowlistConfig([spender], false))
+      expect(await erc20ApprovePolicy.isSpenderAllowed(owner, safe, token, spender)).to.equal(false)
+    })
   })
 })

--- a/test/erc20TransferPolicy.spec.ts
+++ b/test/erc20TransferPolicy.spec.ts
@@ -331,5 +331,24 @@ describe('ERC20TransferPolicy', function () {
       expect(await erc20TransferPolicy.isRecipientAllowed(deployer, ZeroAddress, tokenAddress, recipientAddress)).to.be
         .false
     })
+
+    it('Should reject calldata that is neither transfer nor transferFrom', async function () {
+      // `configure` pins the selector to one of the two, so the engine can only route those here.
+      // This is the policy defending its own decode when called directly, which anyone may do.
+      const { safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      await expect(
+        erc20TransferPolicy.checkTransaction(
+          safe,
+          token,
+          0n,
+          token.interface.encodeFunctionData('approve', [randomAddress(), 1n]),
+          SafeOperation.Call,
+          ZeroAddress,
+          '0x',
+          0n
+        )
+      ).to.be.revertedWithCustomError(erc20TransferPolicy, 'InvalidTransfer')
+    })
   })
 })

--- a/test/multiSendPolicy.spec.ts
+++ b/test/multiSendPolicy.spec.ts
@@ -171,6 +171,25 @@ describe('MultiSendPolicy', function () {
         })
       ).to.not.be.reverted
     })
+
+    it('Should reject calldata that is not a MultiSend batch', async function () {
+      // `configure` pins the selector, so the engine can only route `multiSend` calldata here. This
+      // is the policy defending its own decode when called directly, which anyone may do.
+      const { safe, multiSendPolicy } = await loadFixture(fixture)
+
+      await expect(
+        multiSendPolicy.checkTransaction(
+          safe,
+          randomAddress(),
+          0n,
+          randomSelector(),
+          SafeOperation.DelegateCall,
+          ZeroAddress,
+          '0x',
+          0n
+        )
+      ).to.be.revertedWithCustomError(multiSendPolicy, 'InvalidMultiSend')
+    })
   })
 
   describe('Transaction Validation', function () {

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -384,6 +384,40 @@ describe('SafePolicyGuard', function () {
         })
       ).to.not.be.reverted
     })
+
+    it('Should let a caller that is not a Safe configure its own policies', async function () {
+      // The guard probes for an installed guard with `staticcall(getStorageAt)`. A caller with no
+      // such function and no fallback makes that call revert outright, which must read as "no guard
+      // installed" rather than propagate -- policy state is namespaced by `msg.sender`, so a
+      // non-Safe caller configuring itself is legitimate.
+      const { safePolicyGuard, mockPolicy } = await loadFixture(fixture)
+      const configurer = await (await ethers.getContractFactory('TestNonSafeConfigurer')).deploy()
+      const target = randomAddress()
+
+      await expect(
+        configurer.configure(safePolicyGuard, [createConfiguration({ target, policy: await mockPolicy.getAddress() })])
+      ).to.not.be.reverted
+
+      const [, policy] = await safePolicyGuard.getPolicy(configurer, target, '0x00000000', SafeOperation.Call)
+      expect(policy).to.equal(await mockPolicy.getAddress())
+    })
+
+    it('Should not read revert data from a failed guard-slot probe', async function () {
+      // A caller whose `getStorageAt` reverts with a payload shaped exactly like a successful answer,
+      // planting the guard's own address in the word the guard reads. Only the call status separates
+      // this from a real answer: dropping that check makes the guard read the plant, decide it is
+      // already installed, and refuse the configuration.
+      const { safePolicyGuard, mockPolicy } = await loadFixture(fixture)
+      const configurer = await (await ethers.getContractFactory('TestRevertingStorageConfigurer')).deploy()
+      const target = randomAddress()
+
+      await expect(
+        configurer.configure(safePolicyGuard, [createConfiguration({ target, policy: await mockPolicy.getAddress() })])
+      ).to.not.be.reverted
+
+      const [, policy] = await safePolicyGuard.getPolicy(configurer, target, '0x00000000', SafeOperation.Call)
+      expect(policy).to.equal(await mockPolicy.getAddress())
+    })
   })
 
   describe('requestConfiguration', function () {


### PR DESCRIPTION
Close the coverage gaps left in the policies, and state in NatSpec the four behaviours a reader would otherwise have to infer.

## Context and Motivation

With test-only contracts excluded, production coverage read 99.31% of statements and 94% of branches. The shortfall was a handful of decode guards and fail-closed paths, each of which is exactly the sort of thing an audit asks about. This brings statements, branches and lines to 100%.

The pre-audit review also turned up three documented-nowhere behaviours, all fail-closed or deliberate rather than bugs, and a fourth worth stating beside them. They are recorded here alongside the tests, since both answer the same question about the same contracts.

## Changes

Tests:
- `InvalidMultiSend`, `InvalidApproval` and `InvalidTransfer`: the policies defending their own decode.
- `NoCosignerConfigured`: configuring a zero-address co-signer must fail closed at check time rather than accept any signature.
- `getCoSigner` and `isSpenderAllowed`.
- Two `_readGuardSlot` cases, with `TestNonSafeConfigurer` and `TestRevertingStorageConfigurer`.

NatSpec:
- `CoSignerPolicy`: transaction path only; the `nonce() - 1` derivation assumes an increment `execTransactionFromModule` never performs.
- `NativeTransferPolicy`: the recipient comes from the access selector, and the CALL fallback key permits any amount to any address.
- `ERC20ApprovePolicy`: `approve(spender, 0)` bypasses the allowlist by design.
- `ERC20TransferPolicy`: `transferFrom`'s `from` is deliberately unconstrained.

`.solcover.js` additionally skips `libraries/SignatureExtension.sol`.

## Decisions and Tradeoffs

- The three decode-guard tests call `checkTransaction` directly. The engine keys on the selector, and each policy's `configure` pins which selectors it accepts, so mismatched calldata can never be routed to these policies through a Safe. A direct call is the only thing that reaches the guard, and the policies are permissionless by design.
- `SignatureExtension` is vendored from `safe-research/safenet` -- differing only in the pragma and the SPDX identifier -- which owns its unit tests in `contracts/test/libraries/SignatureExtension.t.sol` -- including both standalone rejection paths. Rather than duplicate them, the file is skipped for coverage with a comment pointing at the upstream tests. It is still exercised end-to-end here through the guard's context decoding.
- The first `_readGuardSlot` test is not sufficient on its own. A plain non-Safe caller reverts with empty return data, which the `returnData.length < 96` check already rejects, so that test still passes with the `!success` condition removed. `TestRevertingStorageConfigurer` reverts with a 96-byte payload shaped like a real answer, planting the guard's own address in the word the guard reads; only the call status separates the two. That test does fail without `!success`.
- The `returnData.length < 96` half of the same condition is deliberately left unpinned. Dropping it is an equivalent mutant: a short answer makes the assembly read past the allocation, and unallocated memory is zero-initialised, so the read yields the same `address(0)` the length check would have returned. Making it observable would need a 65-95 byte answer *and* a guard address ending in `0x00`, and even then the only effect is that the caller blocks its own configuration. The check is defence-in-depth against the over-read; a test asserting it would pass with or without it.
- Coverage now reports one uncovered function, `PolicyEngine._allowedCalls`. Its default body is empty and every engine here overrides it without calling `super`, so the base implementation is unreachable. Left untested and undocumented in the contract, since a note about a coverage artifact does not belong in NatSpec.
- The NatSpec edits leave executable bytecode identical but change the appended solc metadata, so `keccak256(initcode)` -- and therefore the CREATE2 address a deterministic deploy produces -- moves for exactly these four policies. Anyone holding a bytecode or metadata hash for them will see it change from a diff that reads as comment-only.
- Solhint enforces one contract per file, hence two test-contract files.

## Testing

Suite 128 passing, up from 120; build, lint and typecheck green. Coverage is 100% of statements, branches and lines on production contracts. Two of the new tests were checked against a temporarily reverted contract to confirm they fail without the behaviour they cover -- `InvalidTransfer` and the reverting-probe case -- after the second was found to pass regardless on its first attempt.
