### PR TITLE
test: complete the enableGuard adoption

### DIFF
--- a/test/coSignerPolicy.spec.ts
+++ b/test/coSignerPolicy.spec.ts
@@ -68,21 +68,8 @@ describe('CoSignerPolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Get initial balances
       const initialRecipientBalance = await ethers.provider.getBalance(await recipient.getAddress())
@@ -137,21 +124,8 @@ describe('CoSignerPolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Try to execute the transaction without co-signer signature
       await expect(
@@ -182,21 +156,8 @@ describe('CoSignerPolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Create the transaction data
       const txData: TransactionParametersWithNonce = {
@@ -248,21 +209,8 @@ describe('CoSignerPolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Get initial balances
       const initialRecipientBalance = await ethers.provider.getBalance(await recipient.getAddress())

--- a/test/erc20ApprovePolicy.spec.ts
+++ b/test/erc20ApprovePolicy.spec.ts
@@ -6,6 +6,7 @@ import { ethers } from 'hardhat'
 import {
   createConfiguration,
   createSafe,
+  enableGuard,
   encodeAllowlistConfig,
   execTransaction,
   randomAddress,
@@ -64,21 +65,8 @@ describe('ERC20ApprovePolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Verify there was no previous approval
       expect(await token.allowance(await safe.getAddress(), spender)).to.equal(0)
@@ -111,21 +99,8 @@ describe('ERC20ApprovePolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Try to execute the approve transaction
       await expect(
@@ -159,21 +134,8 @@ describe('ERC20ApprovePolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Try to execute a transfer transaction (non-approve)
       await expect(
@@ -213,21 +175,8 @@ describe('ERC20ApprovePolicy', function () {
       // Verify the approval was successful
       expect(await token.allowance(await safe.getAddress(), spender)).to.equal(amount)
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Try to execute the zero amount approve transaction
       await execTransaction({

--- a/test/erc20TransferPolicy.spec.ts
+++ b/test/erc20TransferPolicy.spec.ts
@@ -6,6 +6,7 @@ import { ethers } from 'hardhat'
 import {
   createConfiguration,
   createSafe,
+  enableGuard,
   encodeAllowlistConfig,
   execTransaction,
   randomAddress,
@@ -72,21 +73,8 @@ describe('ERC20TransferPolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Execute the transfer transaction
       await execTransaction({
@@ -115,21 +103,8 @@ describe('ERC20TransferPolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Try to execute a transfer transaction to unconfigured recipient
       await expect(
@@ -162,21 +137,8 @@ describe('ERC20TransferPolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Try to execute an approve transaction (non-transfer)
       await expect(
@@ -207,21 +169,8 @@ describe('ERC20TransferPolicy', function () {
         })
       ]
 
-      // Configure the policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      // Configure the policy, then enable the guard
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
 
       // Approve the Safe to spend tokens (using owner's signer)
       await token.connect(owner).approve(await safe.getAddress(), amount)

--- a/test/multiSendPolicy.spec.ts
+++ b/test/multiSendPolicy.spec.ts
@@ -6,6 +6,7 @@ import { ethers } from 'hardhat'
 import {
   createConfiguration,
   createSafe,
+  enableGuard,
   encodeCoSignerConfig,
   execTransaction,
   safeSignTypedData,
@@ -239,20 +240,7 @@ describe('MultiSendPolicy', function () {
       ]
 
       // Configure the policies for all transactions
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      await enableGuard({ owner, safe, safePolicyGuard, configurations: configurations })
 
       // Build MultiSend transaction
       const safeTx = await buildMultiSendSafeTx(multiSend, txs, await safe.nonce())
@@ -312,20 +300,7 @@ describe('MultiSendPolicy', function () {
       ]
 
       // Configure the policies for all transactions
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      await enableGuard({ owner, safe, safePolicyGuard, configurations: configurations })
 
       // Build MultiSend transaction with an unconfigured transaction
       const txs = [
@@ -361,28 +336,20 @@ describe('MultiSendPolicy', function () {
       const subTarget = randomAddress()
       const amount = ethers.parseEther('1')
 
-      await execTransaction({
-        owners: [owner],
+      await enableGuard({
+        owner,
         safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [
-          [
-            createConfiguration({ target: recipient.address, policy: await allowPolicy.getAddress() }),
-            createConfiguration({ target: subTarget, policy: await mockPolicy.getAddress() }),
-            createConfiguration({
-              target: await multiSend.getAddress(),
-              selector: multiSend.interface.getFunction('multiSend')?.selector,
-              operation: SafeOperation.DelegateCall,
-              policy: await multiSendPolicy.getAddress()
-            })
-          ]
-        ])
-      })
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({ target: recipient.address, policy: await allowPolicy.getAddress() }),
+          createConfiguration({ target: subTarget, policy: await mockPolicy.getAddress() }),
+          createConfiguration({
+            target: await multiSend.getAddress(),
+            selector: multiSend.interface.getFunction('multiSend')?.selector,
+            operation: SafeOperation.DelegateCall,
+            policy: await multiSendPolicy.getAddress()
+          })
+        ]
       })
 
       await mockPolicy.setRevertCheckWithReason(true)
@@ -432,20 +399,7 @@ describe('MultiSendPolicy', function () {
       ]
 
       // Configure the multiSend policy
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [multiSendConfiguration])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      await enableGuard({ owner, safe, safePolicyGuard, configurations: multiSendConfiguration })
 
       const configurationCall = [
         createConfiguration({
@@ -559,20 +513,7 @@ describe('MultiSendPolicy', function () {
       ]
 
       // Configure the policies for all transactions
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safePolicyGuard.getAddress(),
-        data: safePolicyGuard.interface.encodeFunctionData('configureImmediately', [configurations])
-      })
-
-      // Enable the guard on safe
-      await execTransaction({
-        owners: [owner],
-        safe,
-        to: await safe.getAddress(),
-        data: safe.interface.encodeFunctionData('setGuard', [await safePolicyGuard.getAddress()])
-      })
+      await enableGuard({ owner, safe, safePolicyGuard, configurations: configurations })
 
       // Get initial balances
       const initialRecipientBalance = await ethers.provider.getBalance(await recipient.getAddress())


### PR DESCRIPTION
Migrate the last four specs onto `enableGuard`, finishing the deduplication this stack set out to do.

## Context and Motivation

Two earlier PRs moved seven specs onto `enableGuard`, but the plan behind them listed only the specs that had no other helper work. These four were migrated for their *encoding* helpers in earlier PRs and their guard boilerplate was never touched, leaving seventeen inline `configureImmediately` + `setGuard` pairs whose ordering each had to get right independently.

With this, every spec that installs a guard goes through the helper.

## Changes

- `coSignerPolicy.spec.ts`: 4 pairs.
- `multiSendPolicy.spec.ts`: 5 pairs.
- `erc20ApprovePolicy.spec.ts`: 4 pairs.
- `erc20TransferPolicy.spec.ts`: 4 pairs.

## Decisions and Tradeoffs

- `gasBenchmark.spec.ts` keeps its six inline pairs. It enables the guard first and then drives the delayed `requestConfiguration`/`applyConfiguration` path -- the reverse of `enableGuard`'s ordering -- and needs each transaction receipt individually to log gas, so the helper would change what it measures.
- `multiSendPolicy.spec.ts`'s four remaining `configureImmediately` calls are in its `Policy Configuration` block, where the assertion is on `configureImmediately` itself and no guard is installed. Not candidates.

## Testing

Suite 128 passing, unchanged; lint and typecheck green. Every replacement preserves the original call ordering, and the negative tests that would break if it had shifted still pass for their own reasons -- `Unauthorized` for missing and wrong co-signatures, `AccessDenied` for unconfigured targets, and the nested `PolicyReverted` attribution inside a MultiSend batch. Imports were checked for staleness after the substitution.
