### PR TITLE
test: keep benchmarks out of the default run and fold the interface checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,5 @@ jobs:
       # Runs after the build, which generates the TypeChain types it needs.
       - run: npm run build:ts:typecheck
       - run: npm run test
+      # The benchmarks assert nothing, but running them keeps the suite from rotting unnoticed.
+      - run: npm run test:bench

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lint:fix": "npm run lint:fix:sol && npm run lint:fix:ts",
     "lint:fix:sol": "prettier -w contracts/ && solhint 'contracts/**/*.sol' --fix --noPrompt",
     "lint:fix:ts": "eslint --fix",
-    "test": "hardhat test --network hardhat",
-    "test:bench": "hardhat test --grep '@bench'",
+    "test": "hardhat test --network hardhat --grep '^(?!.*\\[@bench\\])'",
+    "test:bench": "hardhat test --network hardhat --grep '\\[@bench\\]'",
     "coverage": "hardhat coverage",
     "verify": "hardhat etherscan-verify --force-license --license LGPL-3.0 --network"
   },

--- a/test/safePolicyGuard.spec.ts
+++ b/test/safePolicyGuard.spec.ts
@@ -66,24 +66,29 @@ describe('SafePolicyGuard', function () {
   })
 
   describe('supportsInterface', function () {
-    it('Should support the PolicyEngine interface', async function () {
+    // Pinned as literals rather than recomputed from the ABI: these IDs are part of the deployed
+    // surface, and deriving them here would let a signature change go unnoticed.
+    const INTERFACE_IDS = {
+      PolicyEngine: '0x04a9e3cd',
+      SafeModuleGuard: '0x58401ed8',
+      SafeTransactionGuard: '0xe6d7a83a',
+      ERC165: '0x01ffc9a7'
+    }
+
+    it('Should support the declared interfaces', async function () {
       const { safePolicyGuard } = await loadFixture(fixture)
-      expect(await safePolicyGuard.supportsInterface('0x04a9e3cd')).to.equal(true)
+
+      for (const [name, id] of Object.entries(INTERFACE_IDS)) {
+        expect(await safePolicyGuard.supportsInterface(id), name).to.equal(true)
+      }
     })
 
-    it('Should support the SafeModuleGuard interface', async function () {
+    it('Should not claim support for an unknown interface', async function () {
+      // Without this, the assertions above would pass just as well against a `supportsInterface`
+      // that returned true unconditionally. `0xffffffff` is the ID ERC-165 requires to be false.
       const { safePolicyGuard } = await loadFixture(fixture)
-      expect(await safePolicyGuard.supportsInterface('0x58401ed8')).to.equal(true)
-    })
 
-    it('Should support the SafeTransactionGuard interface', async function () {
-      const { safePolicyGuard } = await loadFixture(fixture)
-      expect(await safePolicyGuard.supportsInterface('0xe6d7a83a')).to.equal(true)
-    })
-
-    it('Should support the ERC165 interface', async function () {
-      const { safePolicyGuard } = await loadFixture(fixture)
-      expect(await safePolicyGuard.supportsInterface('0x01ffc9a7')).to.equal(true)
+      expect(await safePolicyGuard.supportsInterface('0xffffffff')).to.equal(false)
     })
   })
 


### PR DESCRIPTION
Separate the gas benchmarks from the correctness suite, and collapse four one-line interface assertions into one table-driven test plus the negative case they were missing.

## Context and Motivation

`gasBenchmark.spec.ts` asserts nothing -- it logs gas usage -- but it ran on every `npm test`, mixing measurement output into the correctness signal. It already carries an `[@bench]` tag that `test:bench` greps for, so the default run just needs to exclude it.

The four `supportsInterface` tests differed only in one hex literal and each reloaded the fixture. Folding them together exposed a gap: all four assert only the positive direction, so every one of them passes against a `supportsInterface` that returns `true` unconditionally. The negative case is added here.

## Changes

- `package.json`: `npm test` becomes `hardhat test --network hardhat --grep '^(?!.*\[@bench\])'`, and `test:bench` greps the same anchored tag and gains the `--network hardhat` it was missing.
- `.github/workflows/ci.yml`: run `npm run test:bench` after `npm run test`.
- `test/safePolicyGuard.spec.ts`: the four interface tests become one, iterating a name-to-ID table, plus a test that `0xffffffff` is unsupported.

## Decisions and Tradeoffs

- A negative-lookahead grep rather than mocha's `--invert`, which Hardhat does not forward (`HH305: Unrecognized param --invert`). The tag is matched with its brackets, `\[@bench\]`, so a future test whose title merely mentions the word -- "…@benchmarking", say -- is still run rather than silently skipped.
- CI runs the benchmarks too. They assert nothing, but nothing else would notice if they stopped compiling or reverting, and `npm test` no longer covers them.
- The interface IDs stay hardcoded rather than derived from the ABI. They are part of the deployed surface, and computing them from the same source under test would let a signature change pass unnoticed.
- Each assertion in the folded test passes the interface name as its message, so a failure still identifies which interface regressed.

## Testing

`npm test` 120 passing, `npm run test:bench` 6 passing; lint and typecheck green. The anchoring was checked by adding a deliberately-failing test titled "…mentions @benchmarking": with the unanchored pattern `npm test` reported 121 passing and exit 0, silently excluding it; with the anchored pattern it runs and fails. The count moves from 122 to 120 because four tests became two. The new negative test was checked against a `supportsInterface` stubbed to return `true`: the folded positive test still passed and only the negative one failed, which is the gap it exists to close.
