### PR TITLE
docs: state that AppSafePolicyGuard is not for production use

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,14 @@ npm run deploy -- <network>
 ```
 
 Note: Ensure proper configuration of delay parameters based on your security requirements. 
+
+### `AppSafePolicyGuard` is for the demo only
+
+`SafePolicyGuard` is the guard intended for use. Setting the `DEMO` flag deploys `AppSafePolicyGuard`
+in its place — a subclass that exists so the Safe App demo can read configurations from the contract
+instead of running an indexer. To do that it widens `_allowedCalls` and overrides the configuration
+entry points.
+
+It is recorded in `networks.json` on mainnets as well as testnets, but **those deployments are
+demonstrations and must not be used in production.** It lives under `contracts/test/`, carries no
+tests, and is outside the audited surface.

--- a/contracts/test/App/AppSafePolicyGuard.sol
+++ b/contracts/test/App/AppSafePolicyGuard.sol
@@ -10,6 +10,11 @@ import {IPolicyEngine} from "../../interfaces/IPolicyEngine.sol";
 /**
  * @title App Safe Policy Guard
  * @dev Used for Safe App demo purposes.
+ * @dev NOT FOR PRODUCTION USE, on any network. It is deployed to mainnets as well as testnets so the
+ *      Safe App demo can read configurations from the contract instead of running an indexer, which
+ *      is why it widens `_allowedCalls` and overrides the configuration entry points. Deployment is
+ *      gated behind the `DEMO` flag, and it is untested and outside the audited surface. Use
+ *      {SafePolicyGuard}.
  */
 contract AppSafePolicyGuard is SafePolicyGuard {
     using AccessSelector for AccessSelector.T;


### PR DESCRIPTION
Say plainly, in the contract and the README, that the demo guard must not be used in production on any network.

## Context and Motivation

`AppSafePolicyGuard`'s docblock said only "Used for Safe App demo purposes", which describes its purpose but not the constraint that matters: it must not be relied on, even though `networks.json` records it on Gnosis (chain 100) as well as Sepolia and Base Sepolia. `SafePolicyGuard` is recorded nowhere, so under the `DEMO` flag the demo subclass is what exists on those networks.

Neither README mentioned the contract at all. Anyone finding a live address had nothing telling them what it was.

## Changes

- `AppSafePolicyGuard`: a `@dev` stating it is not for production use on any network, why it exists, that it widens `_allowedCalls` and overrides the configuration entry points, that it is untested and outside the audited surface, and that {SafePolicyGuard} is the guard to use.
- `README.md`: a matching subsection under Deployment.

## Decisions and Tradeoffs

- The warning is duplicated in the contract and the README on purpose. A reader who arrives from a block explorer sees only the contract; a reader who arrives from the repo sees only the README.
- This is a comment-only edit, so executable bytecode is unchanged, but the appended solc metadata is not -- the contract's deterministic deployment address moves. It is a demo contract deployed behind a flag, so the warning is worth more than address stability, and it sits under `contracts/test/`, outside the audited surface.

## Testing

Suite 120 passing and benchmarks 6 passing, both unchanged; build, lint and typecheck green. No test references the contract, and `deploy/deploy_contracts.ts` is untouched.
