### PR TITLE
fix(policies): resolve the zero target in MultiSend batches

### DIFF
--- a/contracts/policies/MultiSendPolicy.sol
+++ b/contracts/policies/MultiSendPolicy.sol
@@ -34,7 +34,7 @@ contract MultiSendPolicy is IPolicy {
         bytes calldata transactions = _decodeMultiSendTransactions(data);
         bytes calldata ctx;
         while (transactions.length > 0) {
-            (to, value, data, operation, transactions) = _decodeNextTransaction(transactions);
+            (to, value, data, operation, transactions) = _decodeNextTransaction(safe, transactions);
             (ctx, context) = _decodeNextContext(context);
             IPolicyEngine(msg.sender).checkTransaction(safe, to, value, data, operation, ctx);
         }
@@ -54,11 +54,20 @@ contract MultiSendPolicy is IPolicy {
         return data[:length];
     }
 
+    /**
+     * @dev Resolves a zero `to` to the Safe, as `MultiSend` itself does. The batch is always a
+     *      `DELEGATECALL` (pinned by {configure}), so its `address(this)` is the Safe; without this
+     *      the checked target and the executed one diverge.
+     */
     function _decodeNextTransaction(
+        address safe,
         bytes calldata transactions
     ) internal pure returns (address to, uint256 value, bytes calldata data, Operation operation, bytes calldata rest) {
         operation = Operation(uint8(transactions[0]));
         to = address(uint160(bytes20(transactions[1:21])));
+        if (to == address(0)) {
+            to = safe;
+        }
         value = uint256(bytes32(transactions[21:53]));
         uint256 dataLength = uint256(bytes32(transactions[53:85]));
         data = transactions[85:85 + dataLength];

--- a/test/multiSendPolicy.spec.ts
+++ b/test/multiSendPolicy.spec.ts
@@ -26,6 +26,7 @@ import {
   deployTestERC20Token,
   deployCoSignerPolicy,
   deployAllowPolicy,
+  deployDenyPolicy,
   deployMockPolicy
 } from './deploy'
 
@@ -55,6 +56,9 @@ describe('MultiSendPolicy', function () {
     // Deploy AllowPolicy contract
     const { allowPolicy } = await deployAllowPolicy()
 
+    // Deploy DenyPolicy contract
+    const { denyPolicy } = await deployDenyPolicy()
+
     // Deploy Test ERC20 Token contract
     const { token } = await deployTestERC20Token()
 
@@ -78,6 +82,7 @@ describe('MultiSendPolicy', function () {
       multiSend,
       coSignerPolicy,
       allowPolicy,
+      denyPolicy,
       token
     }
   }
@@ -585,6 +590,104 @@ describe('MultiSendPolicy', function () {
       expect(finalOtherBalance - initialOtherBalance).to.equal(ethAmount)
       expect(finalRecipientTokenBalance - initialRecipientTokenBalance).to.equal(tokenAmount)
       expect(initialSafeBalance - finalSafeBalance).to.equal(ethAmount * 2n)
+    })
+  })
+  describe('Zero Target Resolution', function () {
+    // `MultiSend` replaces a zero `to` with `address(this)`, which is the Safe because the batch is
+    // delegatecalled. The policy has to resolve it the same way, or the checked target and the
+    // called one diverge.
+    it('Should route a zero target to the Safe rather than to address(0)', async function () {
+      const { owner, safePolicyGuard, safe, multiSendPolicy, multiSend, allowPolicy, other } =
+        await loadFixture(fixture)
+
+      const multiSendSelector = multiSend.interface.getFunction('multiSend')?.selector
+      const addOwnerSelector = safe.interface.getFunction('addOwnerWithThreshold')?.selector
+
+      // The Safe allows exactly one self-administration call, addressed to itself.
+      const configurations = [
+        createConfiguration({
+          target: await safe.getAddress(),
+          selector: addOwnerSelector,
+          policy: await allowPolicy.getAddress()
+        }),
+        createConfiguration({
+          target: await multiSend.getAddress(),
+          selector: multiSendSelector,
+          operation: SafeOperation.DelegateCall,
+          policy: await multiSendPolicy.getAddress()
+        })
+      ]
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
+
+      const txs = [
+        buildSafeTransaction({
+          to: ZeroAddress,
+          data: safe.interface.encodeFunctionData('addOwnerWithThreshold', [other.address, 1]),
+          nonce: 0
+        })
+      ]
+      const safeTx = await buildMultiSendSafeTx(multiSend, txs, await safe.nonce())
+
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await multiSend.getAddress(),
+        data: safeTx.data,
+        operation: SafeOperation.DelegateCall
+      })
+
+      expect(await safe.isOwner(other.address)).to.equal(true)
+    })
+
+    it('Should not let a zero target bypass a policy configured for the Safe', async function () {
+      const { owner, safePolicyGuard, safe, multiSendPolicy, multiSend, allowPolicy, denyPolicy, other } =
+        await loadFixture(fixture)
+
+      const multiSendSelector = multiSend.interface.getFunction('multiSend')?.selector
+      const addOwnerSelector = safe.interface.getFunction('addOwnerWithThreshold')?.selector
+
+      // Self-administration is explicitly denied, while everything else reachable by `CALL` is
+      // permitted through the fallback. Without the zero-target resolution the sub-transaction is
+      // looked up against `address(0)`, misses, and lands on that permissive fallback instead of
+      // the deny -- executing a self-call to the Safe that the Safe forbade.
+      const configurations = [
+        createConfiguration({
+          target: await safe.getAddress(),
+          selector: addOwnerSelector,
+          policy: await denyPolicy.getAddress()
+        }),
+        createConfiguration({
+          policy: await allowPolicy.getAddress() // CALL fallback
+        }),
+        createConfiguration({
+          target: await multiSend.getAddress(),
+          selector: multiSendSelector,
+          operation: SafeOperation.DelegateCall,
+          policy: await multiSendPolicy.getAddress()
+        })
+      ]
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
+
+      const txs = [
+        buildSafeTransaction({
+          to: ZeroAddress,
+          data: safe.interface.encodeFunctionData('addOwnerWithThreshold', [other.address, 1]),
+          nonce: 0
+        })
+      ]
+      const safeTx = await buildMultiSendSafeTx(multiSend, txs, await safe.nonce())
+
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await multiSend.getAddress(),
+          data: safeTx.data,
+          operation: SafeOperation.DelegateCall
+        })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+
+      expect(await safe.isOwner(other.address)).to.equal(false)
     })
   })
 })


### PR DESCRIPTION
`MultiSendPolicy` checked a batch entry with a zero `to` against `address(0)`, while `MultiSend`
executes it as a self-call to the Safe — so the checked target and the executed one diverged.

### Context and Motivation

- `MultiSend` substitutes `address(this)` for a zero `to` ([`MultiSend.sol:44`](https://github.com/safe-global/safe-smart-account/blob/main/contracts/libraries/MultiSend.sol#L44), `to := or(to, mul(iszero(to), address()))`).
- A batch is always reached by `DELEGATECALL` — `MultiSendPolicy.configure` pins that — so `address(this)` is the Safe. Such an entry executes a self-call with the Safe as `msg.sender`: `addOwnerWithThreshold`, `setGuard(0)`, and the rest of the Safe's own administration.
- The policy forwarded the raw zero to the engine, which resolved the access selector for `address(0)`. A policy configured against the Safe's own selectors was skipped, and the check fell through to whichever policy the unrelated selector resolved to — the `CALL` fallback in the common case.

### Testing

- Correct routing: a batch entry with a zero `to` is allowed by a policy configured for the Safe's own address.
- The bypass: `DenyPolicy` on `addOwnerWithThreshold` plus a permissive `CALL` fallback, where the batch must be refused.
- Both verified to fail without the fix. The bypass test does not revert at all, and the attacker becomes an owner of the Safe.
