### PR TITLE
fix(policies): spend a co-signature on use

### DIFF
--- a/contracts/policies/CoSignerPolicy.sol
+++ b/contracts/policies/CoSignerPolicy.sol
@@ -12,6 +12,9 @@ import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/Signa
  * @dev Transaction path only: the `nonce() - 1` below assumes the nonce increment that
  *      `execTransactionFromModule` never performs, so no co-signature can validate on the module
  *      path. It fails closed, but do not rely on this policy to gate module transactions.
+ * @dev Each co-signature is single-use. The hash pins the Safe nonce, but a batch may repeat a
+ *      sub-transaction and {MultiSendPolicy} checks each occurrence separately, so one co-signature
+ *      would otherwise authorise them all. A batch needing the same action twice must vary it.
  */
 contract CoSignerPolicy is IPolicy {
     /**
@@ -21,9 +24,20 @@ contract CoSignerPolicy is IPolicy {
     mapping(address policyGuard => mapping(address safe => mapping(AccessSelector.T access => address cosigner)))
         private $cosigners;
 
+    /**
+     * @dev Co-signed transaction hashes already spent, for each policy guard and Safe.
+     */
+    // solhint-disable-next-line private-vars-leading-underscore
+    mapping(address policyGuard => mapping(address safe => mapping(bytes32 safeTxHash => bool spent))) private $spent;
+
     error Unauthorized();
     error InvalidSelector();
     error NoCosignerConfigured();
+
+    /**
+     * @notice Error indicating the co-signature was already spent within this transaction.
+     */
+    error CoSignatureAlreadySpent();
 
     function checkTransaction(
         address safe,
@@ -34,7 +48,7 @@ contract CoSignerPolicy is IPolicy {
         address,
         bytes calldata context,
         AccessSelector.T access
-    ) external view override returns (bytes4 magicValue) {
+    ) external override returns (bytes4 magicValue) {
         // Compute the Safe transaction hash.
         bytes32 safeTxHash = ISafe(safe).getTransactionHash(
             to,
@@ -58,6 +72,9 @@ contract CoSignerPolicy is IPolicy {
         bool validSignature = SignatureChecker.isValidSignatureNow(cosigner, safeTxHash, context);
         require(validSignature, Unauthorized());
 
+        require(!$spent[msg.sender][safe][safeTxHash], CoSignatureAlreadySpent());
+        $spent[msg.sender][safe][safeTxHash] = true;
+
         return IPolicy.checkTransaction.selector;
     }
 
@@ -78,5 +95,20 @@ contract CoSignerPolicy is IPolicy {
      */
     function getCoSigner(address safe, AccessSelector.T access) external view returns (address cosigner) {
         cosigner = $cosigners[msg.sender][safe][access];
+    }
+
+    /**
+     * @notice Whether a co-signed transaction hash has already been spent.
+     * @param policyGuard The policy guard address.
+     * @param safe The address of the Safe.
+     * @param safeTxHash The co-signed transaction hash.
+     * @return spent Whether the co-signature has been spent.
+     */
+    function isCoSignatureSpent(
+        address policyGuard,
+        address safe,
+        bytes32 safeTxHash
+    ) external view returns (bool spent) {
+        spent = $spent[policyGuard][safe][safeTxHash];
     }
 }

--- a/test/coSignerPolicy.spec.ts
+++ b/test/coSignerPolicy.spec.ts
@@ -4,6 +4,8 @@ import { ZeroAddress } from 'ethers'
 import { ethers } from 'hardhat'
 
 import {
+  buildMultiSendSafeTx,
+  buildSafeTransaction,
   createConfiguration,
   createSafe,
   enableGuard,
@@ -13,7 +15,7 @@ import {
   SafeOperation,
   TransactionParametersWithNonce
 } from '../src/utils'
-import { deploySafeContracts, deploySafePolicyGuard, deployCoSignerPolicy } from './deploy'
+import { deploySafeContracts, deploySafePolicyGuard, deployCoSignerPolicy, deployMultiSendPolicy } from './deploy'
 
 describe('CoSignerPolicy', function () {
   async function fixture() {
@@ -23,7 +25,7 @@ describe('CoSignerPolicy', function () {
     const { safePolicyGuard } = await deploySafePolicyGuard()
 
     // Deploy the Safe contracts
-    const { safeProxyFactory, safe: safeSingleton } = await deploySafeContracts()
+    const { safeProxyFactory, safe: safeSingleton, multiSend } = await deploySafeContracts()
     const safe = await createSafe({
       owner,
       guard: ZeroAddress, // No guard at this point
@@ -34,6 +36,9 @@ describe('CoSignerPolicy', function () {
 
     // Deploy CoSignerPolicy contract
     const { coSignerPolicy } = await deployCoSignerPolicy()
+
+    // Deploy MultiSendPolicy contract
+    const { multiSendPolicy } = await deployMultiSendPolicy()
 
     // Fund the Safe with some ETH
     await owner.sendTransaction({
@@ -49,7 +54,9 @@ describe('CoSignerPolicy', function () {
       other,
       safe,
       safePolicyGuard,
-      coSignerPolicy
+      coSignerPolicy,
+      multiSend,
+      multiSendPolicy
     }
   }
 
@@ -320,6 +327,119 @@ describe('CoSignerPolicy', function () {
       await coSignerPolicy.connect(deployer).configure(safe, access, encodeCoSignerConfig(await cosigner.getAddress()))
 
       expect(await coSignerPolicy.connect(deployer).getCoSigner(safe, access)).to.equal(await cosigner.getAddress())
+    })
+  })
+  describe('Co-Signature Replay', function () {
+    it('Should not let a batch spend the same co-signature more than once', async function () {
+      const { owner, cosigner, recipient, safePolicyGuard, safe, coSignerPolicy, multiSend, multiSendPolicy } =
+        await loadFixture(fixture)
+
+      const amount = ethers.parseEther('1')
+      const multiSendSelector = multiSend.interface.getFunction('multiSend')?.selector
+
+      const configurations = [
+        createConfiguration({
+          target: await recipient.getAddress(),
+          policy: await coSignerPolicy.getAddress(),
+          data: encodeCoSignerConfig(await cosigner.getAddress())
+        }),
+        createConfiguration({
+          target: await multiSend.getAddress(),
+          selector: multiSendSelector,
+          operation: SafeOperation.DelegateCall,
+          policy: await multiSendPolicy.getAddress()
+        })
+      ]
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
+
+      const nonce = await safe.nonce()
+
+      // The co-signer authorises exactly one transfer of `amount`.
+      const transfer: TransactionParametersWithNonce = buildSafeTransaction({
+        to: await recipient.getAddress(),
+        value: amount,
+        data: '0x',
+        nonce
+      })
+      const coSignature = await safeSignTypedData(cosigner, await safe.getAddress(), transfer)
+
+      // The batch presents that same transfer three times, replaying the one co-signature. Every
+      // occurrence derives the same hash, so each check would see a valid signature.
+      const txs = [transfer, transfer, transfer]
+      const multiSendTx = await buildMultiSendSafeTx(multiSend, txs, nonce)
+      const combinedContext = ethers.solidityPacked(
+        ['uint256', 'bytes', 'uint256', 'bytes', 'uint256', 'bytes'],
+        [
+          ethers.dataLength(coSignature.data),
+          coSignature.data,
+          ethers.dataLength(coSignature.data),
+          coSignature.data,
+          ethers.dataLength(coSignature.data),
+          coSignature.data
+        ]
+      )
+
+      const initialSafeBalance = await ethers.provider.getBalance(await safe.getAddress())
+
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await multiSend.getAddress(),
+          data: multiSendTx.data,
+          operation: SafeOperation.DelegateCall,
+          additionalData: combinedContext
+        })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+
+      expect(await ethers.provider.getBalance(await safe.getAddress())).to.equal(initialSafeBalance)
+    })
+
+    it('Should record a co-signature as spent once used', async function () {
+      const { owner, cosigner, recipient, safePolicyGuard, safe, coSignerPolicy } = await loadFixture(fixture)
+
+      const amount = ethers.parseEther('1')
+      const configurations = [
+        createConfiguration({
+          target: await recipient.getAddress(),
+          policy: await coSignerPolicy.getAddress(),
+          data: encodeCoSignerConfig(await cosigner.getAddress())
+        })
+      ]
+      await enableGuard({ owner, safe, safePolicyGuard, configurations })
+
+      const nonce = await safe.nonce()
+      const transfer: TransactionParametersWithNonce = buildSafeTransaction({
+        to: await recipient.getAddress(),
+        value: amount,
+        data: '0x',
+        nonce
+      })
+      const safeTxHash = await safe.getTransactionHash(
+        transfer.to!,
+        transfer.value!,
+        transfer.data!,
+        transfer.operation!,
+        transfer.safeTxGas!,
+        transfer.baseGas!,
+        transfer.gasPrice!,
+        transfer.gasToken!,
+        transfer.refundReceiver!,
+        nonce
+      )
+      const coSignature = await safeSignTypedData(cosigner, await safe.getAddress(), transfer)
+
+      expect(await coSignerPolicy.isCoSignatureSpent(safePolicyGuard, safe, safeTxHash)).to.equal(false)
+
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await recipient.getAddress(),
+        value: amount,
+        additionalData: coSignature.data
+      })
+
+      expect(await coSignerPolicy.isCoSignatureSpent(safePolicyGuard, safe, safeTxHash)).to.equal(true)
     })
   })
 })


### PR DESCRIPTION
A co-signature was replayable within a single transaction, so one signature could authorise a batch
that repeated the same sub-transaction any number of times.

### Context and Motivation

- The derived hash pins the Safe nonce, so a co-signature cannot carry across transactions. But a `multiSend` batch may contain the same sub-transaction more than once, and `MultiSendPolicy` checks each occurrence separately.
- Every occurrence derives an identical hash, so one co-signature satisfied all of them. A co-signer authorising a single USDC transfer authorised as many as the batch cared to repeat.
- This policy exists precisely because the owner set alone is not trusted, so colluding owners could drain the Safe with one honestly-issued co-signature.

### Decisions and Tradeoffs

- The hash is consumed rather than a policy-owned nonce introduced. Consuming keeps the co-signed message identical to the Safe transaction hash, so existing co-signer tooling is unaffected.
- A policy nonce would have changed the signed message and additionally fixed the module path — which stays unusable here and is documented as such.
- Cost: one storage slot per co-signature, and a batch cannot repeat an identical sub-transaction; it must vary the amount or recipient.

### Testing

- The drain: a batch of three identical transfers carrying one co-signature must revert, with the Safe's balance untouched.
- A spent hash is recorded, via the new `isCoSignatureSpent` view.
- Verified to fail without the fix — the batch does not revert, and one 1-ETH co-signature moves 3 ETH.
