### PR TITLE
feat(policies)!: allow single-use ERC-20 grants

### DIFF
--- a/contracts/interfaces/Permission.sol
+++ b/contracts/interfaces/Permission.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.28;
+
+/**
+ * @title Permission
+ * @dev How often an allowlisted account may be used, in ascending order of permissiveness.
+ */
+enum Permission {
+    NONE,
+    ONCE,
+    ALWAYS
+}

--- a/contracts/policies/ERC20ApprovePolicy.sol
+++ b/contracts/policies/ERC20ApprovePolicy.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.28;
 
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
+import {Permission} from "../interfaces/Permission.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";
 
 /**
@@ -10,6 +11,8 @@ import {AccessSelector} from "../libraries/AccessSelector.sol";
  * @dev Allow ERC-20 approvals only for specific spender addresses.
  * @dev `approve(spender, 0)` is permitted for any spender, so revoking never depends on the
  *      allowlist. Any spender's allowance can therefore be zeroed regardless of configuration.
+ * @dev A spender may be allowed indefinitely or once; a {Permission.ONCE} grant is spent by the
+ *      approval that uses it. A zero-amount approval bypasses the allowlist, so it spends nothing.
  */
 contract ERC20ApprovePolicy is IPolicy {
     using AccessSelector for AccessSelector.T;
@@ -17,18 +20,18 @@ contract ERC20ApprovePolicy is IPolicy {
     /**
      * @notice Spender data structure.
      * @param spender The spender address.
-     * @param allowed Whether the spender is allowed to be approved.
+     * @param permission How often the spender may be approved.
      */
     struct SpenderData {
         address spender;
-        bool allowed;
+        Permission permission;
     }
 
     /**
      * @dev Mapping of spenders for each Safe and token.
      */
     // solhint-disable-next-line private-vars-leading-underscore
-    mapping(address policyGuard => mapping(address safe => mapping(address token => mapping(address spender => bool))))
+    mapping(address policyGuard => mapping(address safe => mapping(address token => mapping(address spender => Permission))))
         private $spenders;
 
     /**
@@ -60,10 +63,17 @@ contract ERC20ApprovePolicy is IPolicy {
         address,
         bytes calldata,
         AccessSelector.T
-    ) external view override returns (bytes4 magicValue) {
+    ) external override returns (bytes4 magicValue) {
         address token = to;
         (address spender, uint256 amount) = _decodeERC20Approve(data);
-        require(amount == 0 || $spenders[msg.sender][safe][token][spender], Unauthorized());
+        // Revoking an allowance is always permitted, and leaves any grant untouched.
+        if (amount != 0) {
+            Permission permission = $spenders[msg.sender][safe][token][spender];
+            require(permission != Permission.NONE, Unauthorized());
+            if (permission == Permission.ONCE) {
+                delete $spenders[msg.sender][safe][token][spender];
+            }
+        }
         return IPolicy.checkTransaction.selector;
     }
 
@@ -92,25 +102,25 @@ contract ERC20ApprovePolicy is IPolicy {
         require(operation == Operation.CALL, InvalidOperation());
         SpenderData[] memory spenderList = abi.decode(data, (SpenderData[]));
         for (uint256 i = 0; i < spenderList.length; i++) {
-            $spenders[msg.sender][safe][target][spenderList[i].spender] = spenderList[i].allowed;
+            $spenders[msg.sender][safe][target][spenderList[i].spender] = spenderList[i].permission;
         }
         return true;
     }
 
     /**
-     * @notice Check if a spender is allowed for a specific Safe and token.
+     * @notice Get the permission recorded for a spender on a specific Safe and token.
      * @param policyGuard The address of the policy guard.
      * @param safe The Safe address.
      * @param token The token address.
      * @param spender The spender address.
-     * @return bool True if the spender is allowed, false otherwise.
+     * @return permission How often the spender may still be approved.
      */
-    function isSpenderAllowed(
+    function getSpenderPermission(
         address policyGuard,
         address safe,
         address token,
         address spender
-    ) external view returns (bool) {
-        return $spenders[policyGuard][safe][token][spender];
+    ) external view returns (Permission permission) {
+        permission = $spenders[policyGuard][safe][token][spender];
     }
 }

--- a/contracts/policies/ERC20TransferPolicy.sol
+++ b/contracts/policies/ERC20TransferPolicy.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.28;
 
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
+import {Permission} from "../interfaces/Permission.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";
 
 /**
@@ -10,6 +11,8 @@ import {AccessSelector} from "../libraries/AccessSelector.sol";
  * @dev Allow ERC-20 transfers only to a specific address list.
  * @dev `transferFrom`'s `from` argument is deliberately unconstrained: the policy restricts where
  *      tokens may go, not whose tokens they are.
+ * @dev A recipient may be allowed indefinitely or once; a {Permission.ONCE} grant is spent by
+ *      the transfer that uses it.
  */
 contract ERC20TransferPolicy is IPolicy {
     using AccessSelector for AccessSelector.T;
@@ -17,18 +20,18 @@ contract ERC20TransferPolicy is IPolicy {
     /**
      * @notice Recipient data structure.
      * @param recipient The recipient address.
-     * @param allowed Whether the recipient is allowed to receive tokens.
+     * @param permission How often the recipient may receive tokens.
      */
     struct RecipientData {
         address recipient;
-        bool allowed;
+        Permission permission;
     }
 
     /**
      * @dev Mapping of recipients for each Safe and token.
      */
     // solhint-disable-next-line private-vars-leading-underscore
-    mapping(address policyGuard => mapping(address safe => mapping(address token => mapping(address recipient => bool))))
+    mapping(address policyGuard => mapping(address safe => mapping(address token => mapping(address recipient => Permission))))
         private $recipients;
 
     /**
@@ -60,10 +63,14 @@ contract ERC20TransferPolicy is IPolicy {
         address,
         bytes calldata,
         AccessSelector.T
-    ) external view override returns (bytes4 magicValue) {
+    ) external override returns (bytes4 magicValue) {
         address token = to;
         address recipient = _decodeERC20Transfer(data);
-        require($recipients[msg.sender][safe][token][recipient], Unauthorized());
+        Permission permission = $recipients[msg.sender][safe][token][recipient];
+        require(permission != Permission.NONE, Unauthorized());
+        if (permission == Permission.ONCE) {
+            delete $recipients[msg.sender][safe][token][recipient];
+        }
         return IPolicy.checkTransaction.selector;
     }
 
@@ -96,25 +103,25 @@ contract ERC20TransferPolicy is IPolicy {
         RecipientData[] memory recipientList = abi.decode(data, (RecipientData[]));
         for (uint256 i = 0; i < recipientList.length; i++) {
             // solhint-disable-next-line reentrancy
-            $recipients[msg.sender][safe][target][recipientList[i].recipient] = recipientList[i].allowed;
+            $recipients[msg.sender][safe][target][recipientList[i].recipient] = recipientList[i].permission;
         }
         return true;
     }
 
     /**
-     * @notice Check if a recipient is allowed for a specific Safe and token.
+     * @notice Get the permission recorded for a recipient on a specific Safe and token.
      * @param policyGuard The policy guard address.
      * @param safe The Safe address.
      * @param token The token address.
      * @param recipient The recipient address.
-     * @return bool Whether the recipient is allowed.
+     * @return permission How often the recipient may still receive tokens.
      */
-    function isRecipientAllowed(
+    function getRecipientPermission(
         address policyGuard,
         address safe,
         address token,
         address recipient
-    ) external view returns (bool) {
-        return $recipients[policyGuard][safe][token][recipient];
+    ) external view returns (Permission permission) {
+        permission = $recipients[policyGuard][safe][token][recipient];
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,18 +125,27 @@ export function encodeOneTimeGrantConfig(granted = true): string {
 }
 
 /**
+ * How often an allowlisted account may be used, mirroring the `Permission` enum in Solidity.
+ */
+export enum Permission {
+  None = 0,
+  Once = 1,
+  Always = 2
+}
+
+/**
  * Encodes `ERC20ApprovePolicy` and `ERC20TransferPolicy` configuration data.
  * @param accounts The accounts to grant or revoke -- spenders for `ERC20ApprovePolicy`, recipients
  *        for `ERC20TransferPolicy`. An empty list configures the access selector without allowing
  *        anyone.
- * @param allowed Whether the accounts are allowed; pass `false` to revoke.
- * @dev Both policies take an `(address, bool)` array (`SpenderData` and `RecipientData`), so one
- *      encoder serves both.
+ * @param permission How often the accounts may be used; pass {Permission.None} to revoke.
+ * @dev Both policies take an `(address, Permission)` array (`SpenderData` and `RecipientData`), so
+ *      one encoder serves both.
  */
-export function encodeAllowlistConfig(accounts: string[], allowed = true): string {
+export function encodeAllowlistConfig(accounts: string[], permission = Permission.Always): string {
   return ethers.AbiCoder.defaultAbiCoder().encode(
-    ['tuple(address account, bool allowed)[]'],
-    [accounts.map((account) => ({ account, allowed }))]
+    ['tuple(address account, uint8 permission)[]'],
+    [accounts.map((account) => ({ account, permission }))]
   )
 }
 

--- a/test/erc20ApprovePolicy.spec.ts
+++ b/test/erc20ApprovePolicy.spec.ts
@@ -8,6 +8,7 @@ import {
   createSafe,
   enableGuard,
   encodeAllowlistConfig,
+  Permission,
   execTransaction,
   randomAddress,
   SafeOperation
@@ -260,8 +261,8 @@ describe('ERC20ApprovePolicy', function () {
     })
   })
 
-  describe('isSpenderAllowed', function () {
-    it('Should report whether a spender is allowed for a Safe and token', async function () {
+  describe('getSpenderPermission', function () {
+    it('Should report the permission recorded for a spender', async function () {
       // State is namespaced by `msg.sender`, which the getter takes explicitly, so configuring
       // directly makes the deployer the namespace to query.
       const { owner, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
@@ -273,14 +274,85 @@ describe('ERC20ApprovePolicy', function () {
       )
       const spender = randomAddress()
 
-      expect(await erc20ApprovePolicy.isSpenderAllowed(owner, safe, token, spender)).to.equal(false)
+      expect(await erc20ApprovePolicy.getSpenderPermission(owner, safe, token, spender)).to.equal(Permission.None)
 
       await erc20ApprovePolicy.connect(owner).configure(safe, access, encodeAllowlistConfig([spender]))
-      expect(await erc20ApprovePolicy.isSpenderAllowed(owner, safe, token, spender)).to.equal(true)
+      expect(await erc20ApprovePolicy.getSpenderPermission(owner, safe, token, spender)).to.equal(Permission.Always)
 
-      // The same call can revoke, which is why `configure` takes a flag per entry.
-      await erc20ApprovePolicy.connect(owner).configure(safe, access, encodeAllowlistConfig([spender], false))
-      expect(await erc20ApprovePolicy.isSpenderAllowed(owner, safe, token, spender)).to.equal(false)
+      // A one-time grant is recorded distinctly from an open-ended one.
+      await erc20ApprovePolicy.connect(owner).configure(safe, access, encodeAllowlistConfig([spender], Permission.Once))
+      expect(await erc20ApprovePolicy.getSpenderPermission(owner, safe, token, spender)).to.equal(Permission.Once)
+
+      // The same call can revoke, which is why `configure` takes a permission per entry.
+      await erc20ApprovePolicy.connect(owner).configure(safe, access, encodeAllowlistConfig([spender], Permission.None))
+      expect(await erc20ApprovePolicy.getSpenderPermission(owner, safe, token, spender)).to.equal(Permission.None)
+    })
+  })
+
+  describe('One-Time Grants', function () {
+    it('Should spend a one-time spender grant on the first approval', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      const spender = randomAddress()
+      const amount = ethers.parseEther('100')
+
+      await enableGuard({
+        owner,
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target: await token.getAddress(),
+            selector: token.interface.getFunction('approve').selector,
+            policy: await erc20ApprovePolicy.getAddress(),
+            data: encodeAllowlistConfig([spender], Permission.Once)
+          })
+        ]
+      })
+
+      const approve = token.interface.encodeFunctionData('approve', [spender, amount])
+
+      await execTransaction({ owners: [owner], safe, to: await token.getAddress(), data: approve })
+      expect(await token.allowance(safe, spender)).to.equal(amount)
+      expect(await erc20ApprovePolicy.getSpenderPermission(safePolicyGuard, safe, token, spender)).to.equal(
+        Permission.None
+      )
+
+      await expect(
+        execTransaction({ owners: [owner], safe, to: await token.getAddress(), data: approve })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+    })
+
+    it('Should not spend a one-time grant on a zero-amount approval', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      const spender = randomAddress()
+
+      await enableGuard({
+        owner,
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target: await token.getAddress(),
+            selector: token.interface.getFunction('approve').selector,
+            policy: await erc20ApprovePolicy.getAddress(),
+            data: encodeAllowlistConfig([spender], Permission.Once)
+          })
+        ]
+      })
+
+      // Revoking an allowance bypasses the allowlist entirely, so it must not burn the grant.
+      await execTransaction({
+        owners: [owner],
+        safe,
+        to: await token.getAddress(),
+        data: token.interface.encodeFunctionData('approve', [spender, 0])
+      })
+
+      expect(await erc20ApprovePolicy.getSpenderPermission(safePolicyGuard, safe, token, spender)).to.equal(
+        Permission.Once
+      )
     })
   })
 })

--- a/test/erc20TransferPolicy.spec.ts
+++ b/test/erc20TransferPolicy.spec.ts
@@ -8,6 +8,7 @@ import {
   createSafe,
   enableGuard,
   encodeAllowlistConfig,
+  Permission,
   execTransaction,
   randomAddress,
   SafeOperation
@@ -271,14 +272,17 @@ describe('ERC20TransferPolicy', function () {
 
       // First, allow the recipient
       await erc20TransferPolicy.configure(ZeroAddress, access, encodeAllowlistConfig([recipientAddress]))
-      expect(await erc20TransferPolicy.isRecipientAllowed(deployer, ZeroAddress, tokenAddress, recipientAddress)).to.be
-        .true
+      expect(
+        await erc20TransferPolicy.getRecipientPermission(deployer, ZeroAddress, tokenAddress, recipientAddress)
+      ).to.equal(Permission.Always)
 
       // Then, disallow the same recipient
-      await expect(erc20TransferPolicy.configure(ZeroAddress, access, encodeAllowlistConfig([recipientAddress], false)))
-        .to.not.be.reverted
-      expect(await erc20TransferPolicy.isRecipientAllowed(deployer, ZeroAddress, tokenAddress, recipientAddress)).to.be
-        .false
+      await expect(
+        erc20TransferPolicy.configure(ZeroAddress, access, encodeAllowlistConfig([recipientAddress], Permission.None))
+      ).to.not.be.reverted
+      expect(
+        await erc20TransferPolicy.getRecipientPermission(deployer, ZeroAddress, tokenAddress, recipientAddress)
+      ).to.equal(Permission.None)
     })
 
     it('Should reject calldata that is neither transfer nor transferFrom', async function () {
@@ -298,6 +302,74 @@ describe('ERC20TransferPolicy', function () {
           0n
         )
       ).to.be.revertedWithCustomError(erc20TransferPolicy, 'InvalidTransfer')
+    })
+  })
+
+  describe('One-Time Grants', function () {
+    it('Should spend a one-time recipient grant on the first transfer', async function () {
+      const { owner, recipient, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      const amount = ethers.parseEther('100')
+      const recipientAddress = await recipient.getAddress()
+
+      await enableGuard({
+        owner,
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target: await token.getAddress(),
+            selector: token.interface.getFunction('transfer').selector,
+            policy: await erc20TransferPolicy.getAddress(),
+            data: encodeAllowlistConfig([recipientAddress], Permission.Once)
+          })
+        ]
+      })
+
+      const transfer = token.interface.encodeFunctionData('transfer', [recipientAddress, amount])
+
+      await execTransaction({ owners: [owner], safe, to: await token.getAddress(), data: transfer })
+      expect(await token.balanceOf(recipientAddress)).to.equal(amount)
+      expect(await erc20TransferPolicy.getRecipientPermission(safePolicyGuard, safe, token, recipientAddress)).to.equal(
+        Permission.None
+      )
+
+      // The grant is spent, so an identical transfer is now unauthorised.
+      await expect(
+        execTransaction({ owners: [owner], safe, to: await token.getAddress(), data: transfer })
+      ).to.be.revertedWithCustomError(safePolicyGuard, 'PolicyReverted')
+
+      expect(await token.balanceOf(recipientAddress)).to.equal(amount)
+    })
+
+    it('Should leave an open-ended grant in place across transfers', async function () {
+      const { owner, recipient, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      const amount = ethers.parseEther('100')
+      const recipientAddress = await recipient.getAddress()
+
+      await enableGuard({
+        owner,
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target: await token.getAddress(),
+            selector: token.interface.getFunction('transfer').selector,
+            policy: await erc20TransferPolicy.getAddress(),
+            data: encodeAllowlistConfig([recipientAddress], Permission.Always)
+          })
+        ]
+      })
+
+      const transfer = token.interface.encodeFunctionData('transfer', [recipientAddress, amount])
+      await execTransaction({ owners: [owner], safe, to: await token.getAddress(), data: transfer })
+      await execTransaction({ owners: [owner], safe, to: await token.getAddress(), data: transfer })
+
+      expect(await token.balanceOf(recipientAddress)).to.equal(amount * 2n)
+      expect(await erc20TransferPolicy.getRecipientPermission(safePolicyGuard, safe, token, recipientAddress)).to.equal(
+        Permission.Always
+      )
     })
   })
 })


### PR DESCRIPTION
The ERC-20 allowlist value becomes a `Permission` — `NONE`, `ONCE` or `ALWAYS` — so a Safe can
authorise a single transfer or approval rather than an open-ended one.

### Context and Motivation

- Both ERC-20 policies allowlisted an account indefinitely. A Safe wanting to authorise one specific payout had no way to say so; the permission stayed until a second timelocked change removed it.
- A `ONCE` grant is spent by the transfer or approval that uses it, during the check, so a `multiSend` batch cannot repeat a sub-transaction to consume one grant twice.

### Decisions and Tradeoffs

- `Permission` replaces the `bool` rather than sitting beside it as a second flag. A `(address, bool, bool)` shape would admit a meaningless state — not allowed, but one-time — whereas the enum makes the three states exhaustive and rejects anything outside them on decode.
- Members are named on a single axis, *how often*, so none reads as the negation of another, and are ordered by ascending permissiveness.
- **Breaking:** the struct field is renamed `allowed` → `permission`, and `isSpenderAllowed` / `isRecipientAllowed` become `getSpenderPermission` / `getRecipientPermission`, since a boolean can no longer describe the state. Existing configuration data has to be re-encoded.
- `approve(spender, 0)` continues to bypass the allowlist, so revoking an allowance stays possible for any spender — and therefore never spends a one-time grant.
- Both policies lose `view`, as the check now writes.

### Testing

- Four new tests: a `ONCE` recipient grant is spent by the first transfer and the identical second is refused; an `ALWAYS` grant survives repeated transfers; a `ONCE` spender grant is spent by the first approval; and a zero-amount approval leaves a `ONCE` grant intact.
- The existing permission-toggle and view tests were extended to cover all three states.
