### PR TITLE
chore: compile with solc 0.8.30

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -8,7 +8,7 @@
     "immutable-vars-naming": ["error", { "immutablesAsConstants": true }],
     "gas-custom-errors": "warn",
     "no-unused-import": "error",
-    "compiler-version": ["error", "0.8.28"],
+    "compiler-version": ["error", "0.8.30"],
     "func-visibility": ["warn", { "ignoreConstructors": true }]
   }
 }

--- a/contracts/SafePolicyGuard.sol
+++ b/contracts/SafePolicyGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {PolicyEngine, AccessSelector} from "./core/PolicyEngine.sol";
 import {IERC165} from "./interfaces/IERC165.sol";

--- a/contracts/core/PolicyEngine.sol
+++ b/contracts/core/PolicyEngine.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {IPolicy} from "../interfaces/IPolicy.sol";
 import {IPolicyEngine} from "../interfaces/IPolicyEngine.sol";

--- a/contracts/interfaces/IERC1271.sol
+++ b/contracts/interfaces/IERC1271.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 /**
  * @title ERC-1271 Interface

--- a/contracts/interfaces/IERC165.sol
+++ b/contracts/interfaces/IERC165.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 /**
  * @title ERC-165 Interface

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 /**
  * @title ERC-20 Interface

--- a/contracts/interfaces/IMultiSend.sol
+++ b/contracts/interfaces/IMultiSend.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 /**
  * @title Multi Send Library Interface

--- a/contracts/interfaces/IPolicy.sol
+++ b/contracts/interfaces/IPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {Operation} from "./Operation.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";

--- a/contracts/interfaces/IPolicyEngine.sol
+++ b/contracts/interfaces/IPolicyEngine.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {Operation} from "./Operation.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";

--- a/contracts/interfaces/ISafe.sol
+++ b/contracts/interfaces/ISafe.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {Operation} from "./Operation.sol";
 

--- a/contracts/interfaces/ISafeModuleGuard.sol
+++ b/contracts/interfaces/ISafeModuleGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {IERC165} from "./IERC165.sol";
 import {Operation} from "./Operation.sol";

--- a/contracts/interfaces/ISafeTransactionGuard.sol
+++ b/contracts/interfaces/ISafeTransactionGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {IERC165} from "./IERC165.sol";
 import {Operation} from "./Operation.sol";

--- a/contracts/interfaces/Operation.sol
+++ b/contracts/interfaces/Operation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 /**
  * @title Operation

--- a/contracts/interfaces/Permission.sol
+++ b/contracts/interfaces/Permission.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 /**
  * @title Permission

--- a/contracts/libraries/AccessSelector.sol
+++ b/contracts/libraries/AccessSelector.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {Operation} from "../interfaces/Operation.sol";
 

--- a/contracts/libraries/SignatureExtension.sol
+++ b/contracts/libraries/SignatureExtension.sol
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 /**
  * @title SignatureExtension
  * @notice A reusable format for appending typed, variable-length data after a Safe's owner signatures.
  * @dev Vendored from `safe-research/safenet` at commit
  *      `1b3c9422600a03d69c4048a160d39b0e32401f28`, path
- *      `contracts/src/libraries/SignatureExtension.sol`. Only the pragma differs, relaxed from
- *      `^0.8.30` so it compiles with this package's pinned `0.8.28`. Keep the two in sync.
+ *      `contracts/src/libraries/SignatureExtension.sol`. Keep the two in sync.
  *
  *      A *signature extension* is a self-describing envelope appended to Safe's `signatures` bytes.
  *      Safe's own signature parser reads owner signatures front-to-back and ignores trailing bytes, so a

--- a/contracts/policies/AllowPolicy.sol
+++ b/contracts/policies/AllowPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";

--- a/contracts/policies/AllowedModulePolicy.sol
+++ b/contracts/policies/AllowedModulePolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";

--- a/contracts/policies/CoSignerPolicy.sol
+++ b/contracts/policies/CoSignerPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {ISafe} from "../interfaces/ISafe.sol";

--- a/contracts/policies/DenyPolicy.sol
+++ b/contracts/policies/DenyPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";

--- a/contracts/policies/ERC20ApprovePolicy.sol
+++ b/contracts/policies/ERC20ApprovePolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";

--- a/contracts/policies/ERC20TransferPolicy.sol
+++ b/contracts/policies/ERC20TransferPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";

--- a/contracts/policies/IncreasedThresholdPolicy.sol
+++ b/contracts/policies/IncreasedThresholdPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {ISafe} from "../interfaces/ISafe.sol";

--- a/contracts/policies/MultiSendPolicy.sol
+++ b/contracts/policies/MultiSendPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {IMultiSend} from "../interfaces/IMultiSend.sol";
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";

--- a/contracts/policies/NativeTransferPolicy.sol
+++ b/contracts/policies/NativeTransferPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";

--- a/contracts/policies/OneTimeAllowPolicy.sol
+++ b/contracts/policies/OneTimeAllowPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";

--- a/contracts/test/App/AppSafePolicyGuard.sol
+++ b/contracts/test/App/AppSafePolicyGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {SafePolicyGuard, AccessSelector, Operation} from "../../SafePolicyGuard.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/contracts/test/ContextRecorderPolicy.sol
+++ b/contracts/test/ContextRecorderPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";

--- a/contracts/test/MockPolicy.sol
+++ b/contracts/test/MockPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";

--- a/contracts/test/ReentrantConfigurePolicy.sol
+++ b/contracts/test/ReentrantConfigurePolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {AccessSelector} from "../libraries/AccessSelector.sol";

--- a/contracts/test/ReentrantMockPolicy.sol
+++ b/contracts/test/ReentrantMockPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {IPolicy, Operation} from "../interfaces/IPolicy.sol";
 import {IPolicyEngine} from "../interfaces/IPolicyEngine.sol";

--- a/contracts/test/TestAccessSelector.sol
+++ b/contracts/test/TestAccessSelector.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {AccessSelector} from "../libraries/AccessSelector.sol";
 import {Operation} from "../interfaces/Operation.sol";

--- a/contracts/test/TestERC20Token.sol
+++ b/contracts/test/TestERC20Token.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity =0.8.28;
+pragma solidity =0.8.30;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/TestImports.sol
+++ b/contracts/test/TestImports.sol
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0
+// Pinned to the version the `hardhat.config.ts` override compiles this file with: the Safe
+// contracts it pulls in are built without the IR pipeline, separately from this package's sources.
+// solhint-disable-next-line compiler-version
 pragma solidity 0.8.28;
 
 /* solhint-disable no-unused-import */

--- a/contracts/test/TestModule.sol
+++ b/contracts/test/TestModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {Operation} from "../interfaces/Operation.sol";
 import {ISafe} from "../interfaces/ISafe.sol";

--- a/contracts/test/TestNonSafeConfigurer.sol
+++ b/contracts/test/TestNonSafeConfigurer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {SafePolicyGuard} from "../SafePolicyGuard.sol";
 

--- a/contracts/test/TestRevertingStorageConfigurer.sol
+++ b/contracts/test/TestRevertingStorageConfigurer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.30;
 
 import {SafePolicyGuard} from "../SafePolicyGuard.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,7 +38,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.28',
+        version: '0.8.30',
         settings: {
           // Pinned explicitly: this is Hardhat's current default, but relying on the default would
           // let a Hardhat upgrade silently change the deployed bytecode.


### PR DESCRIPTION
Re-lands #92. That PR was merged into `feat/increased-threshold-policy` two minutes after #95 had already squash-merged that branch into main, so the bump never reached main.