### PR TITLE
chore: vendor the Safenet crypto libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
+      # Re-downloads the vendored Safenet sources at the commit each file records and diffs them,
+      # so a local edit or a stale pin fails the build rather than going unnoticed.
+      - run: npm run vendor:check
 
   tests:
     runs-on: ubuntu-latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+# Vendored verbatim from `safe-research/safenet`; see `.solhintignore` for the rationale. Listed
+# here as well because `npm run lint:fix:sol` invokes `prettier -w contracts/` directly, which
+# would otherwise rewrite them regardless of the solhint ignore.
+contracts/libraries/ConsensusMessages.sol
+contracts/libraries/EpochRollover.sol
+contracts/libraries/FROST.sol
+contracts/libraries/Secp256k1.sol
+contracts/libraries/SignatureExtension.sol

--- a/.solcover.js
+++ b/.solcover.js
@@ -4,10 +4,15 @@ module.exports = {
     // them buries the production numbers -- `AppSafePolicyGuard` alone is never exercised by the
     // suite and drags the total down by around 15 points.
     'test/',
-    // Vendored verbatim from `safe-research/safenet`, which owns its unit tests:
-    // `contracts/test/libraries/SignatureExtension.t.sol`. Its standalone rejection paths are
-    // covered there rather than duplicated here; this repo exercises it end-to-end through the
-    // guard's context decoding.
-    'libraries/SignatureExtension.sol'
+    // Vendored verbatim from `safe-research/safenet`, which owns their unit tests under
+    // `contracts/test/libraries/` (`SignatureExtension.t.sol`, `FROST.t.sol`, `Secp256k1.t.sol`,
+    // `ConsensusMessages.t.sol`, `EpochRollover.t.sol`). Their standalone paths are covered there
+    // rather than duplicated here; this repo exercises them end-to-end through the guard's context
+    // decoding and `SafenetPolicy`.
+    'libraries/SignatureExtension.sol',
+    'libraries/ConsensusMessages.sol',
+    'libraries/EpochRollover.sol',
+    'libraries/FROST.sol',
+    'libraries/Secp256k1.sol'
   ]
 }

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,0 +1,8 @@
+# Vendored verbatim from `safe-research/safenet`, which formats with `forge fmt` and owns the
+# lint rules these files were written against. Reformatting them here would make them undiffable
+# against upstream, which is how they are kept in sync and reviewed.
+contracts/libraries/ConsensusMessages.sol
+contracts/libraries/EpochRollover.sol
+contracts/libraries/FROST.sol
+contracts/libraries/Secp256k1.sol
+contracts/libraries/SignatureExtension.sol

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Note: If the Safe reactivates the guard, this policy should be removed. This nee
 
 ## Deployment note
 
+Contracts compile for the **Cancun** EVM, which the vendored Safenet libraries require (they use `mcopy`). Chains that have not activated the Cancun upgrade are not deployment targets.
+
 Every change to the guard changes its bytecode and therefore its CREATE2 address. Existing deployments must be redeployed and Safes re-pointed at the new address; a Safe keeps referencing whichever address it was given.
 
 ## Testing

--- a/contracts/libraries/ConsensusMessages.sol
+++ b/contracts/libraries/ConsensusMessages.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.30;
+// Vendored from `safe-research/safenet` at `5de7e86900b27844d00458d8dc85cbaa0d27f2ea`,
+// `contracts/src/libraries/ConsensusMessages.sol`. Only the licence header and the `@/libraries/`
+// import alias differ; `npm run vendor:check` enforces that.
+
+import {Secp256k1} from "./Secp256k1.sol";
+
+/**
+ * @title Consensus Messages
+ * @notice Library for computing consensus messages that are signed by the validator set.
+ */
+library ConsensusMessages {
+    // ============================================================
+    // CONSTANTS
+    // ============================================================
+
+    /**
+     * @custom:precomputed keccak256("EIP712Domain(uint256 chainId,address verifyingContract)")
+     */
+    bytes32 internal constant DOMAIN_TYPEHASH = hex"47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218";
+
+    /**
+     * @custom:precomputed keccak256("EpochRollover(uint64 activeEpoch,uint64 proposedEpoch,uint64 rolloverBlock,uint256 groupKeyX,uint256 groupKeyY)")
+     */
+    bytes32 internal constant EPOCH_ROLLOVER_TYPEHASH =
+        hex"13de01993286119c9a7628720a5b7d7c32841dbf2d23752b59de86a7e03fe1bf";
+
+    /**
+     * @custom:precomputed keccak256("TransactionProposal(uint64 epoch,address oracle,bytes oracleData,bytes32 safeTxHash)")
+     */
+    bytes32 internal constant TRANSACTION_PROPOSAL_TYPEHASH =
+        hex"9c6706f5afdb1de99f5ad39011e7770ce471f51d78380634f6cedb21a648b8d0";
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Computes the domain separator hash.
+     * @param chainId The chain ID.
+     * @param verifyingContract The address of the verifying contract.
+     * @return result The domain separator hash.
+     */
+    function domain(uint256 chainId, address verifyingContract) internal pure returns (bytes32 result) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+            mstore(ptr, DOMAIN_TYPEHASH)
+            mstore(add(ptr, 0x20), chainId)
+            mstore(add(ptr, 0x40), verifyingContract)
+            result := keccak256(ptr, 0x60)
+        }
+    }
+
+    /**
+     * @notice Computes the epoch rollover message that must be signed by the active group.
+     * @param domainSeparator The EIP-712 domain separator.
+     * @param activeEpoch The current active epoch.
+     * @param proposedEpoch The proposed new epoch.
+     * @param rolloverBlock The block number for the rollover.
+     * @param groupKey The group public key.
+     * @return result The epoch rollover message hash.
+     */
+    function epochRollover(
+        bytes32 domainSeparator,
+        uint64 activeEpoch,
+        uint64 proposedEpoch,
+        uint64 rolloverBlock,
+        Secp256k1.Point memory groupKey
+    ) internal pure returns (bytes32 result) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+            mstore(ptr, EPOCH_ROLLOVER_TYPEHASH)
+            mstore(add(ptr, 0x20), activeEpoch)
+            mstore(add(ptr, 0x40), proposedEpoch)
+            mstore(add(ptr, 0x60), rolloverBlock)
+            mcopy(add(ptr, 0x80), groupKey, 0x40)
+            mstore(add(ptr, 0x22), keccak256(ptr, 0xc0))
+            mstore(ptr, hex"1901")
+            mstore(add(ptr, 0x02), domainSeparator)
+            result := keccak256(ptr, 0x42)
+        }
+    }
+
+    /**
+     * @notice Computes the transaction proposal message that must be attested to by validators.
+     * @dev The message's `bytes oracleData` member is EIP-712 encoded as its `keccak256`, so callers pass the
+     *      pre-computed `oracleDataHash` directly. A caller holding the full data (e.g. `proposeTransaction`) hashes
+     *      it at the callsite; a caller holding only the hash (the guard, from its attestation trailer) uses it as-is.
+     *      Either way the raw data stays with the oracle contract and is never needed to rebuild the signed message.
+     * @param domainSeparator The EIP-712 domain separator.
+     * @param epoch The epoch for the transaction proposal.
+     * @param oracle The address of the oracle contract used for evaluation.
+     * @param oracleDataHash The `keccak256` of the arbitrary oracle-specific data.
+     * @param safeTxHash The hash of the Safe transaction.
+     * @return result The transaction proposal message hash, used as the oracle requestId.
+     */
+    function transactionProposal(
+        bytes32 domainSeparator,
+        uint64 epoch,
+        address oracle,
+        bytes32 oracleDataHash,
+        bytes32 safeTxHash
+    ) internal pure returns (bytes32 result) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+            mstore(ptr, TRANSACTION_PROPOSAL_TYPEHASH)
+            mstore(add(ptr, 0x20), epoch)
+            mstore(add(ptr, 0x40), oracle)
+            mstore(add(ptr, 0x60), oracleDataHash)
+            mstore(add(ptr, 0x80), safeTxHash)
+            mstore(add(ptr, 0x22), keccak256(ptr, 0xa0))
+            mstore(ptr, hex"1901")
+            mstore(add(ptr, 0x02), domainSeparator)
+            result := keccak256(ptr, 0x42)
+        }
+    }
+}

--- a/contracts/libraries/EpochRollover.sol
+++ b/contracts/libraries/EpochRollover.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.30;
+// Vendored from `safe-research/safenet` at `5de7e86900b27844d00458d8dc85cbaa0d27f2ea`,
+// `contracts/src/libraries/EpochRollover.sol`. Only the licence header and the `@/libraries/`
+// import alias differ; `npm run vendor:check` enforces that.
+
+import {ConsensusMessages} from "./ConsensusMessages.sol";
+import {FROST} from "./FROST.sol";
+import {Secp256k1} from "./Secp256k1.sol";
+
+/**
+ * @title EpochRollover
+ * @notice Tracks the set of trusted `(group key, epoch)` pairs forming the Safenet epoch attestation
+ *         chain, and advances it by verifying FROST-signed epoch rollovers.
+ * @dev The set is a forest rooted at the genesis epoch: each rollover is signed by an already-known
+ *      parent group and records its successor. Every pair is kept forever (no pruning) and every
+ *      validly-signed branch is accepted — fork choice and retention are deliberately out of scope
+ *      for v1.
+ */
+library EpochRollover {
+    // ============================================================
+    // STRUCTS
+    // ============================================================
+
+    /**
+     * @notice The set of trusted epoch group keys.
+     * @custom:param entries Maps a group key's coordinates and an epoch to whether that
+     *               `(group key, epoch)` pair is trusted. The same epoch may hold several keys (reorg
+     *               branches) and the same key may appear at several epochs, both without collision.
+     */
+    struct T {
+        mapping(uint256 groupKeyX => mapping(uint256 groupKeyY => mapping(uint64 epoch => bool known))) entries;
+    }
+
+    // ============================================================
+    // EVENTS
+    // ============================================================
+
+    /**
+     * @notice Emitted when the genesis `(group key, epoch)` pair is seeded.
+     * @param epoch The genesis epoch number.
+     * @param groupKey The genesis group public key.
+     */
+    event EpochInitialized(uint64 indexed epoch, Secp256k1.Point groupKey);
+
+    /**
+     * @notice Emitted when a rollover records a new `(group key, epoch)` pair. Both endpoints are
+     *         included so the forest can be reconstructed off-chain.
+     * @param parentEpoch The epoch rolled over from.
+     * @param epoch The newly recorded epoch.
+     * @param parentKey The group key that signed the rollover.
+     * @param groupKey The newly recorded group public key.
+     */
+    event EpochRolledOver(
+        uint64 indexed parentEpoch, uint64 indexed epoch, Secp256k1.Point parentKey, Secp256k1.Point groupKey
+    );
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown when the proposed epoch is not strictly greater than the parent epoch.
+     */
+    error EpochNotAdvancing();
+
+    /**
+     * @notice Thrown when the `(parentKey, parentEpoch)` pair a rollover extends is not in the set.
+     */
+    error UnknownParent();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Seeds the trusted genesis pair, the root of the attestation chain.
+     * @dev Must be called exactly once (e.g. in the consumer's constructor). Genesis is trusted
+     *      directly, so no signature is verified.
+     * @param self The storage struct.
+     * @param genesisEpoch The genesis epoch number.
+     * @param genesisKey The genesis group public key; must be a non-zero curve point.
+     */
+    function initialize(T storage self, uint64 genesisEpoch, Secp256k1.Point memory genesisKey) internal {
+        Secp256k1.requireNonZero(genesisKey);
+        self.entries[genesisKey.x][genesisKey.y][genesisEpoch] = true;
+        emit EpochInitialized(genesisEpoch, genesisKey);
+    }
+
+    /**
+     * @notice Verifies a FROST-signed rollover from a known parent and records the new pair.
+     * @dev Verification runs before the membership write, so a successful call always implies a
+     *      valid signature. The write is idempotent: re-submitting an already-known pair is a no-op
+     *      (no revert, no event), so reorg replays and racing submitters are harmless.
+     * @param self The storage struct.
+     * @param domainSeparator The EIP-712 domain separator binding the signature to the Consensus deployment.
+     * @param parentKey The group key being rolled over from; the `(parentKey, parentEpoch)` pair must be known.
+     * @param parentEpoch The epoch of `parentKey`.
+     * @param proposedEpoch The new epoch; must be strictly greater than `parentEpoch`.
+     * @param rolloverBlock Folded into the verified message but not checked here — a Consensus-chain
+     *        block number with no meaning on a remote chain.
+     * @param newGroupKey The new group public key; must be a non-zero curve point.
+     * @param signature The FROST signature produced by the parent group over the rollover message.
+     */
+    function rollover(
+        T storage self,
+        bytes32 domainSeparator,
+        Secp256k1.Point memory parentKey,
+        uint64 parentEpoch,
+        uint64 proposedEpoch,
+        uint64 rolloverBlock,
+        Secp256k1.Point memory newGroupKey,
+        FROST.Signature memory signature
+    ) internal {
+        require(isKnown(self, parentKey, parentEpoch), UnknownParent());
+        require(proposedEpoch > parentEpoch, EpochNotAdvancing());
+        Secp256k1.requireNonZero(newGroupKey);
+
+        bytes32 message =
+            ConsensusMessages.epochRollover(domainSeparator, parentEpoch, proposedEpoch, rolloverBlock, newGroupKey);
+        FROST.verify(parentKey, signature, message);
+
+        if (!isKnown(self, newGroupKey, proposedEpoch)) {
+            self.entries[newGroupKey.x][newGroupKey.y][proposedEpoch] = true;
+            emit EpochRolledOver(parentEpoch, proposedEpoch, parentKey, newGroupKey);
+        }
+    }
+
+    /**
+     * @notice Returns whether the `(groupKey, epoch)` pair has been recorded.
+     * @dev Membership is exact on the pair: a known key at a different epoch returns false.
+     * @param self The storage struct.
+     * @param groupKey The group public key to check.
+     * @param epoch The epoch to check.
+     * @return known True if the `(groupKey, epoch)` pair is recorded.
+     */
+    function isKnown(T storage self, Secp256k1.Point memory groupKey, uint64 epoch) internal view returns (bool known) {
+        return self.entries[groupKey.x][groupKey.y][epoch];
+    }
+}

--- a/contracts/libraries/FROST.sol
+++ b/contracts/libraries/FROST.sol
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.30;
+// Vendored from `safe-research/safenet` at `5de7e86900b27844d00458d8dc85cbaa0d27f2ea`,
+// `contracts/src/libraries/FROST.sol`. Only the licence header and the `@/libraries/`
+// import alias differ; `npm run vendor:check` enforces that.
+
+import {Secp256k1} from "./Secp256k1.sol";
+
+/**
+ * @title FROST
+ * @notice Implementation of the FROST(secp256k1, SHA-256) ciphersuite.
+ * @dev FROST Implementation based on [RFC-9591](https://datatracker.ietf.org/doc/html/rfc9591). In particular, it
+ *      implements the FROST(secp256k1, SHA-256) ciphersuite from Section 6.5.
+ */
+library FROST {
+    using Secp256k1 for Secp256k1.Point;
+
+    // ============================================================
+    // TYPES AND STRUCTS
+    // ============================================================
+
+    /**
+     * @notice Group commitment used in FROST signing.
+     * @custom:param participant The participant address associated with this commitment.
+     * @custom:param d The hiding nonce commitment point.
+     * @custom:param e The binding nonce commitment point.
+     */
+    struct Commitment {
+        address participant;
+        Secp256k1.Point d;
+        Secp256k1.Point e;
+    }
+
+    /**
+     * @notice A FROST group signature.
+     * @custom:param r The group commitment represented as a point.
+     * @custom:param z The scalar signature component.
+     */
+    struct Signature {
+        Secp256k1.Point r;
+        uint256 z;
+    }
+
+    /**
+     * @notice A FROST signature share for a single participant.
+     * @custom:param r The participant commitment represented as a point.
+     * @custom:param z The participant scalar share.
+     * @custom:param l The Lagrange coefficient for this participant.
+     */
+    struct SignatureShare {
+        Secp256k1.Point r;
+        uint256 z;
+        uint256 l;
+    }
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown when commitments are not strictly ordered by participant.
+     */
+    error UnorderedCommitments();
+
+    /**
+     * @notice Thrown when a scalar is not reduced modulo the curve order.
+     */
+    error InvalidScalar();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Derives a FROST participant identifier for a given address.
+     * @param participant The participant address.
+     * @return id The derived identifier.
+     */
+    function identifier(address participant) internal view returns (uint256 id) {
+        return _hid(abi.encodePacked(participant));
+    }
+
+    /**
+     * @notice Generates a random nonce from randomness and a secret key.
+     * @param random The source randomness.
+     * @param secret The participant secret key.
+     * @return n The derived nonce scalar.
+     * @dev Implements the RFC-9591 `nonce_generate` function
+     *      (https://datatracker.ietf.org/doc/html/rfc9591#section-4.1).
+     */
+    function nonce(bytes32 random, uint256 secret) internal view returns (uint256 n) {
+        return _h3(abi.encodePacked(random, secret));
+    }
+
+    /**
+     * @notice Computes the binding factors for a message and group commitments.
+     * @param y The group public key.
+     * @param commitments The list of participant commitments.
+     * @param message The message being signed.
+     * @return rho The binding factors for each participant.
+     * @dev Implements the RFC-9591 `compute_binding_factors` function.
+     */
+    function bindingFactors(Secp256k1.Point memory y, Commitment[] memory commitments, bytes32 message)
+        internal
+        view
+        returns (uint256[] memory rho)
+    {
+        // The RFC-9591 `compute_binding_factors` function.
+        // <https://datatracker.ietf.org/doc/html/rfc9591#section-4.4>
+        //
+        // This implementation uses identifiers derived from the participant's address.
+        // <https://github.com/ZcashFoundation/frost/blob/3ffc19d8f473d5bc4e07ed41bc884bdb42d6c29f/frost-core/src/identifier.rs#L50-L62>
+
+        (uint8 yv, bytes32 yx) = y.serialize();
+        bytes32 msgHash = _h4(abi.encode(message));
+        bytes32 commitmentsHash = _h5(_encodeCommitments(commitments));
+        bytes memory rhoInput = abi.encodePacked(yv, yx, msgHash, commitmentsHash, uint256(0));
+        uint256 rhoIndexPtr;
+        assembly ("memory-safe") {
+            rhoIndexPtr := add(rhoInput, 0x81)
+        }
+
+        rho = new uint256[](commitments.length);
+        for (uint256 i = 0; i < commitments.length; i++) {
+            uint256 id = identifier(commitments[i].participant);
+            assembly ("memory-safe") {
+                mstore(rhoIndexPtr, id)
+            }
+            rho[i] = _h1(rhoInput);
+        }
+    }
+
+    /**
+     * @notice Computes the challenge for a message from a group commitment and group public key.
+     * @param r The participant commitment represented as a point.
+     * @param y The group public key.
+     * @param message The message being signed.
+     * @return c The computed challenge scalar.
+     * @dev Implements the RFC-9591 `compute_challenge` function.
+     */
+    function challenge(Secp256k1.Point memory r, Secp256k1.Point memory y, bytes32 message)
+        internal
+        view
+        returns (uint256 c)
+    {
+        // The RFC-9591 `compute_challenge` function.
+        // <https://datatracker.ietf.org/doc/html/rfc9591#section-4.6>
+
+        (uint8 rv, bytes32 rx) = r.serialize();
+        (uint8 yv, bytes32 yx) = y.serialize();
+        return _h2(abi.encodePacked(rv, rx, yv, yx, message));
+    }
+
+    /**
+     * @notice Verifies a FROST group signature.
+     * @param y The group public key.
+     * @param signature The FROST signature to verify.
+     * @param message The signed message.
+     */
+    function verify(Secp256k1.Point memory y, Signature memory signature, bytes32 message) internal view {
+        require(signature.z < Secp256k1.N, InvalidScalar());
+        uint256 c = challenge(signature.r, y, message);
+        Secp256k1.mulmuladd(signature.z, c, y, signature.r);
+    }
+
+    /**
+     * @notice Verifies a FROST signature share.
+     * @param group The group public key.
+     * @param r The participant commitment represented as a point.
+     * @param participant The participant public key.
+     * @param share The signature share to verify.
+     * @param message The signed message.
+     */
+    function verifyShare(
+        Secp256k1.Point memory group,
+        Secp256k1.Point memory r,
+        Secp256k1.Point memory participant,
+        SignatureShare memory share,
+        bytes32 message
+    ) internal view {
+        require(share.z < Secp256k1.N, InvalidScalar());
+        uint256 c = challenge(r, group, message);
+        uint256 cl = mulmod(c, share.l, Secp256k1.N);
+        Secp256k1.mulmuladd(share.z, cl, participant, share.r);
+    }
+
+    /**
+     * @notice Generates a key generation challenge for the proof of knowledge.
+     * @param participant The participant address.
+     * @param phi The participant public key share.
+     * @param r The commitment point used in the proof.
+     * @return c The computed challenge scalar.
+     * @dev Matches the official FROST implementation KeyGen `challenge` function.
+     */
+    function keyGenChallenge(address participant, Secp256k1.Point memory phi, Secp256k1.Point memory r)
+        internal
+        view
+        returns (uint256 c)
+    {
+        // The official FROST implementation KeyGen `challenge` function.
+        // <https://github.com/ZcashFoundation/frost/blob/3ffc19d8f473d5bc4e07ed41bc884bdb42d6c29f/frost-core/src/keys/dkg.rs#L413-L430>
+        // <https://github.com/ZcashFoundation/frost/blob/3ffc19d8f473d5bc4e07ed41bc884bdb42d6c29f/frost-secp256k1/src/lib.rs#L222-L224>
+
+        uint256 id = identifier(participant);
+        (uint8 phiv, bytes32 phix) = phi.serialize();
+        (uint8 rv, bytes32 rx) = r.serialize();
+        return _hdkg(abi.encodePacked(id, phiv, phix, rv, rx));
+    }
+
+    // ============================================================
+    // PRIVATE FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Encodes a list of commitments into the RFC-9591 group commitment list format.
+     * @param commitments The commitments to encode.
+     * @return result The encoded commitment list.
+     */
+    function _encodeCommitments(Commitment[] memory commitments) private view returns (bytes memory result) {
+        // The RFC-9591 `encode_group_commitment_list` function.
+        // <https://datatracker.ietf.org/doc/html/rfc9591#section-4.3>
+        //
+        // This implementation uses identifiers derived from the participant's address.
+        // <https://github.com/ZcashFoundation/frost/blob/3ffc19d8f473d5bc4e07ed41bc884bdb42d6c29f/frost-core/src/identifier.rs#L50-L62>
+
+        result = new bytes(commitments.length * 98);
+
+        uint256 last = 0;
+        for (uint256 i = 0; i < commitments.length; i++) {
+            Commitment memory commitment = commitments[i];
+            uint256 id = identifier(commitment.participant);
+            require(id > last, UnorderedCommitments());
+            last = id;
+            (uint8 dv, bytes32 dx) = commitment.d.serialize();
+            (uint8 ev, bytes32 ex) = commitment.e.serialize();
+            assembly ("memory-safe") {
+                let ptr := add(add(result, 0x20), mul(i, 98))
+                mstore(ptr, id)
+                mstore8(add(ptr, 0x20), dv)
+                mstore(add(ptr, 0x21), dx)
+                mstore8(add(ptr, 0x41), ev)
+                mstore(add(ptr, 0x42), ex)
+            }
+        }
+    }
+
+    /**
+     * @notice H1: Hashes input to a field element for calculating binding factors (rho).
+     * @param input The input bytes.
+     * @return result The field element.
+     * @dev Uses a domain separation tag "FROST-secp256k1-SHA256-v1rho" as required by RFC 9591, Section 6.5. The DST
+     *      is packed into a bytes32 with its length (28 / 0x1c) as the final byte.
+     */
+    function _h1(bytes memory input) private view returns (uint256 result) {
+        return _hashToField(input, "FROST-secp256k1-SHA256-v1rho\x00\x00\x00\x1c");
+    }
+
+    /**
+     * @notice H2: Hashes input to a field element for calculating the per-message challenge (c).
+     * @param input The input bytes, which include group commitment, group public key, and the message.
+     * @return result The field element.
+     * @dev Uses a domain separation tag "FROST-secp256k1-SHA256-v1chal" as required by RFC 9591, Section 6.5. The
+     *      length of the DST is 29 (0x1d).
+     */
+    function _h2(bytes memory input) private view returns (uint256 result) {
+        return _hashToField(input, "FROST-secp256k1-SHA256-v1chal\x00\x00\x1d");
+    }
+
+    /**
+     * @notice H3: Hashes input to a field element for generating nonces.
+     * @param input The input bytes, which include participant-specific randomness and the secret key.
+     * @return result The field element.
+     * @dev Uses a domain separation tag "FROST-secp256k1-SHA256-v1nonce" as required by RFC 9591, Section 6.5. The
+     *      length of the DST is 30 (0x1e).
+     */
+    function _h3(bytes memory input) private view returns (uint256 result) {
+        return _hashToField(input, "FROST-secp256k1-SHA256-v1nonce\x00\x1e");
+    }
+
+    /**
+     * @notice H4: Hashes the message before it is used in the binding factor computation.
+     * @param input The message bytes.
+     * @return result The 32-byte hash.
+     * @dev Uses a domain separation tag "FROST-secp256k1-SHA256-v1msg" as required by RFC 9591, Section 6.5. The
+     *      length of the DST is 28 (0x1c).
+     */
+    function _h4(bytes memory input) private view returns (bytes32 result) {
+        return _hash(input, "FROST-secp256k1-SHA256-v1msg\x00\x00\x00\x1c");
+    }
+
+    /**
+     * @notice H5: Hashes the list of nonce commitments for the binding factor computation.
+     * @param input The encoded commitment list.
+     * @return result The 32-byte hash.
+     * @dev Uses a domain separation tag "FROST-secp256k1-SHA256-v1com" as required by RFC 9591, Section 6.5. The
+     *      length of the DST is 28 (0x1c).
+     */
+    function _h5(bytes memory input) private view returns (bytes32 result) {
+        return _hash(input, "FROST-secp256k1-SHA256-v1com\x00\x00\x00\x1c");
+    }
+
+    /**
+     * @notice HDKG: Hashes input to a field element for key generation challenges.
+     * @param input The input bytes, which include identifier, public key share, and commitment point.
+     * @return result The field element.
+     * @dev Uses a domain separation tag "FROST-secp256k1-SHA256-v1dkg" inspired by the Zcash Foundation reference
+     *      implementation. This ensures the challenge is unique to the DKG context. The length of the DST is 28 (0x1c).
+     */
+    function _hdkg(bytes memory input) private view returns (uint256 result) {
+        // The FROST(secp256k1, SHA-256) `HDKG` function.
+        // <https://github.com/ZcashFoundation/frost/blob/3ffc19d8f473d5bc4e07ed41bc884bdb42d6c29f/frost-secp256k1/src/lib.rs#L221-L224>
+
+        return _hashToField(input, "FROST-secp256k1-SHA256-v1dkg\x00\x00\x00\x1c");
+    }
+
+    /**
+     * @notice HID: Hashes input to a field element for deterministic FROST identifiers.
+     * @param input The encoded participant address.
+     * @return result The field element.
+     * @dev Uses a domain separation tag "FROST-secp256k1-SHA256-v1id" inspired by the Zcash Foundation reference
+     *      implementation. This ensures the identifiers are unique with uniform distribution per participant. The
+     *      length of the DST is 27 (0x1b).
+     */
+    function _hid(bytes memory input) private view returns (uint256 result) {
+        // The FROST(secp256k1, SHA-256) `HID` function.
+        // <https://github.com/ZcashFoundation/frost/blob/3ffc19d8f473d5bc4e07ed41bc884bdb42d6c29f/frost-secp256k1/src/lib.rs#L226-L229>
+
+        return _hashToField(input, "FROST-secp256k1-SHA256-v1id\x00\x00\x00\x00\x1b");
+    }
+
+    /**
+     * @notice Hashes a message to a field element modulo Secp256k1.N.
+     * @param message The message to hash.
+     * @param dst The domain separation tag.
+     * @return e The resulting field element.
+     */
+    function _hashToField(bytes memory message, bytes32 dst) private view returns (uint256 e) {
+        // The RFC-9380 `hash_to_field` function with:
+        // - F: the finite field of order Secp256k1.N
+        // - p: Secp256k1.N (field modulus)
+        // - m: 1 (number of elements to generate)
+        // - L: 48 (byte-length of intermediate value, for 128-bit security)
+        // <https://datatracker.ietf.org/doc/html/rfc9380#section-5.2>
+
+        bytes memory uniform = _expandMessageXmd(message, dst, 48);
+        uint256 n = Secp256k1.N;
+        assembly ("memory-safe") {
+            e := mulmod(mload(add(uniform, 0x20)), 0x100000000000000000000000000000000, n)
+            e := addmod(e, shr(128, mload(add(uniform, 0x40))), n)
+        }
+    }
+
+    /**
+     * @notice Expands a message using SHA-256 XMD.
+     * @param message The message to expand.
+     * @param dst The domain separation tag. The string is packed into a bytes32 with its length as the final byte.
+     * @param len The desired output length in bytes.
+     * @return uniform The expanded pseudo-random bytes.
+     * @dev Implements the RFC-9380 `expand_message_xmd` function with SHA-256.
+     */
+    function _expandMessageXmd(bytes memory message, bytes32 dst, uint256 len)
+        private
+        view
+        returns (bytes memory uniform)
+    {
+        // The RFC-9380 `expand_message_xmd` function with:
+        // - H: SHA-256
+        // - b_in_bytes: 32
+        // - s_in_bytes: 64
+        // <https://datatracker.ietf.org/doc/html/rfc9380#section-5.3.1>
+
+        assert(len < 0x8000);
+        assembly ("memory-safe") {
+            function _sha256(inputPtr, inputLen, outputPtr) {
+                if iszero(
+                    and(eq(returndatasize(), 0x20), staticcall(gas(), 0x2, inputPtr, inputLen, outputPtr, 0x20))
+                ) {
+                    revert(0x00, 0x00)
+                }
+            }
+
+            uniform := mload(0x40)
+            mstore(0x40, add(uniform, and(add(0x3f, len), 0xffe0)))
+            mstore(uniform, len)
+
+            let prime := mload(0x40)
+            let ptr := prime
+
+            mstore(ptr, 0)
+            ptr := add(ptr, 0x20)
+            mstore(ptr, 0)
+            ptr := add(ptr, 0x20)
+
+            mcopy(ptr, add(message, 0x20), mload(message))
+            ptr := add(ptr, mload(message))
+            mstore(ptr, shl(240, len))
+            ptr := add(ptr, 0x03)
+
+            let bPtr := sub(ptr, 0x21)
+            let iPtr := sub(ptr, 0x01)
+
+            mstore(ptr, dst)
+            let dstLen := byte(31, dst)
+            ptr := add(ptr, dstLen)
+            mstore8(ptr, dstLen)
+            ptr := add(ptr, 0x01)
+
+            let bLen := sub(ptr, bPtr)
+
+            _sha256(prime, sub(ptr, prime), bPtr)
+            let b0 := mload(bPtr)
+            mstore8(iPtr, 1)
+            _sha256(bPtr, bLen, add(uniform, 0x20))
+            for { let i := 2 } gt(len, 0x20) {
+                i := add(i, 1)
+                len := sub(len, 32)
+            } {
+                let uPtr := add(uniform, shl(5, i))
+                mstore(bPtr, xor(b0, mload(sub(uPtr, 0x20))))
+                mstore8(iPtr, i)
+                _sha256(bPtr, bLen, uPtr)
+            }
+        }
+    }
+
+    /**
+     * @notice Computes a SHA-256 hash of input with a domain separation tag.
+     * @param input The input message.
+     * @param dst The domain separation tag.
+     * @return digest The resulting hash.
+     */
+    function _hash(bytes memory input, bytes32 dst) private view returns (bytes32 digest) {
+        assembly ("memory-safe") {
+            let dstLen := byte(31, dst)
+            let dstOffset := sub(32, dstLen)
+            let len := mload(input)
+            mstore(input, shr(shl(3, dstOffset), dst))
+            if iszero(
+                and(
+                    eq(returndatasize(), 0x20),
+                    staticcall(gas(), 0x2, add(input, dstOffset), add(len, dstLen), 0x00, 0x20)
+                )
+            ) { revert(0x00, 0x00) }
+            digest := mload(0x00)
+            mstore(input, len)
+        }
+    }
+}

--- a/contracts/libraries/Secp256k1.sol
+++ b/contracts/libraries/Secp256k1.sol
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.30;
+// Vendored from `safe-research/safenet` at `5de7e86900b27844d00458d8dc85cbaa0d27f2ea`,
+// `contracts/src/libraries/Secp256k1.sol`. Only the licence header and the `@/libraries/`
+// import alias differ; `npm run vendor:check` enforces that.
+
+/**
+ * @title Secp256k1
+ * @notice Secp256k1 curve operations.
+ */
+library Secp256k1 {
+    // ============================================================
+    // STRUCTS
+    // ============================================================
+
+    /**
+     * @notice Represents a point on the secp256k1 curve.
+     * @custom:param x The x-coordinate of the point.
+     * @custom:param y The y-coordinate of the point.
+     */
+    struct Point {
+        uint256 x;
+        uint256 y;
+    }
+
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
+    /**
+     * @notice Thrown when a point is not on the curve.
+     */
+    error NotOnCurve();
+
+    /**
+     * @notice Thrown when the witness for mulmuladd is invalid.
+     */
+    error InvalidMulMulAddWitness();
+
+    // ============================================================
+    // CONSTANTS
+    // ============================================================
+
+    /**
+     * @notice The 'b' coefficient of the secp256k1 curve equation y² = x³ + ax + b.
+     * @dev For secp256k1, the 'a' coefficient is 0, and 'b' is 7. This is a defining parameter of the curve, as
+     *      specified in "SEC 2: Recommended Elliptic Curve Domain Parameters".
+     */
+    uint256 internal constant B = 7;
+
+    /**
+     * @notice The prime field modulus for secp256k1, defining the finite field F_p.
+     * @dev All arithmetic operations on the curve's coordinates are performed modulo this prime number. Its value is
+     *      2^256 - 2^32 - 977 as specified in SEC 2.
+     */
+    uint256 internal constant P = 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f;
+
+    /**
+     * @notice The order of the generator point of the secp256k1 curve.
+     * @dev All scalar arithmetic are performed modulo N.
+     */
+    uint256 internal constant N = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141;
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Computes `R = P + Q`.
+     * @param p The first point.
+     * @param q The second point.
+     * @return r The resulting point from the addition.
+     * @dev See <https://www.hyperelliptic.org/EFD/g1p/auto-shortw.html> Since we are doing a single addition per
+     *      transaction; we just implement the affine formulas instead of the projective formulas (which are typically
+     *      considered more efficient when doing multiple point additions at a time). The additional gas cost of
+     *      storing the projective `Z` coordinate in storage is higher than the additional cost of the extra arithmetic
+     *      from using affine coordinates. Note that we optimize the computation to do as few `_divmod`s as possible
+     *      (one per operation), as that is by far the most expensive computation (~200 gas for the `modexp` precompile
+     *      call).
+     */
+    function add(Point memory p, Point memory q) internal view returns (Point memory r) {
+        (uint256 px, uint256 py) = _unpack(p);
+        (uint256 qx, uint256 qy) = _unpack(q);
+
+        uint256 l;
+        if (px | py == 0) {
+            // `P` is the point at infinity, and `0 + Q = Q`.
+            return q;
+        } else if (qx | qy == 0) {
+            // `Q` is the point at infinity, and `P + 0 = P`.
+            return p;
+        } else if (px != qx) {
+            // Point addition, compute the slope through `P` and `Q`:
+            //     λ = (Qy - Py) / (Qx - Px)
+            unchecked {
+                l = _divmod(addmod(qy, P - py, P), addmod(qx, P - px, P), P);
+            }
+        } else if (py == qy) {
+            // Point doubling, compute the slope of the tangent at `P`:
+            //     λ = (3⋅Px² + a) / (2⋅Py)
+            //       = (3⋅Px²) / (2⋅Py)
+            // Noting that `a = 0` for the `secp256k1` curve.
+            unchecked {
+                l = _divmod(mulmod(3, mulmod(px, px, P), P), addmod(py, py, P), P);
+            }
+        } else {
+            // This branch happens iff `P = -P` in which case their sum is the point at infinity (represented by the
+            // 0-value) that `r` is initialized with.
+            return r;
+        }
+
+        // Compute the coordinates for the point `R`:
+        //     Rx = λ² - Px - Qx
+        //        = λ² - (Px + Qx)
+        //     Ry = (2⋅Px + Qx)⋅λ - λ³ - Py
+        //        = (2⋅Px + Qx - λ²)⋅λ - Py
+        //        = (Px - (λ² - (Px + Qx)))⋅λ - Py
+        //        = (Px - Rx)⋅λ - Py
+        // Noting that `Px = Qx` for point doubling.
+        unchecked {
+            r.x = addmod(mulmod(l, l, P), P - addmod(px, qx, P), P);
+            r.y = addmod(mulmod(addmod(px, P - r.x, P), l, P), P - py, P);
+        }
+        return r;
+    }
+
+    /**
+     * @notice Verifies that `z⋅G - e⋅P = R`.
+     * @param z The scalar multiplier for the generator point.
+     * @param e The scalar multiplier for point P.
+     * @param p The point P.
+     * @param r The expected result point R (witness).
+     * @dev See <https://ethresear.ch/t/you-can-kinda-abuse-ecrecover-to-do-ecmul-in-secp256k1-today/2384> This
+     *      function uses a trick to abuse the `ecrecover` precompile in order to compute a mul-mul-add operation of
+     *      `-z` times the curve generator point plus `e` time the point `P` defined by the coordinates `Px` and `Py`.
+     *      The caveat with this trick is that it doesn't return the resulting point, but a public address (which is a
+     *      truncated hash of the resulting point's coordinates, and why we require a witness `r` instead of just
+     *      returning a result). Additionally, it only supports points `P` with x-coordinates that are elements in Fn.
+     *      In practice (assuming uniform distribution of x-coordinates), this happens for roughly one in every 3.7e39
+     *      points and is negligible.
+     */
+    function mulmuladd(uint256 z, uint256 e, Point memory p, Point memory r) internal view {
+        (uint256 px, uint256 py) = _unpack(p);
+        (uint256 rx, uint256 ry) = _unpack(r);
+        bool valid;
+        assembly ("memory-safe") {
+            // Perform `ecrecover(z * Px, v, Px, e * Px) = address(-R)`
+            let ptr := mload(0x40)
+            mstore(ptr, mulmod(z, px, N))
+            mstore(add(ptr, 0x20), add(and(py, 1), 27))
+            mstore(add(ptr, 0x40), px)
+            mstore(add(ptr, 0x60), mulmod(e, px, N))
+            let minusR :=
+                mul(mload(0x00), and(eq(returndatasize(), 0x20), staticcall(gas(), 0x1, ptr, 0x80, 0x00, 0x20)))
+
+            // Compute `address(-R)` from the provided witness `r` and check it matches the result of the `ecrecover`
+            // operation.
+            mstore(0x00, rx)
+            mstore(0x20, sub(P, ry))
+            valid := eq(minusR, and(keccak256(0x00, 0x40), 0xffffffffffffffffffffffffffffffffffffffff))
+        }
+        require(valid, InvalidMulMulAddWitness());
+    }
+
+    /**
+     * @notice Returns whether `P` equals `Q`.
+     * @param p The first point.
+     * @param q The second point.
+     * @return result True if the points are equal, false otherwise.
+     */
+    function eq(Point memory p, Point memory q) internal pure returns (bool result) {
+        (uint256 px, uint256 py) = _unpack(p);
+        (uint256 qx, uint256 qy) = _unpack(q);
+        return (px ^ qx) | (py ^ qy) == 0;
+    }
+
+    /**
+     * @notice Requires that `P` is a non-zero point on the curve.
+     * @param p The point to validate.
+     */
+    function requireNonZero(Point memory p) internal pure {
+        require(_satisfiesCurveEquation(p.x, p.y), NotOnCurve());
+    }
+
+    /**
+     * @notice Serializes a point to its compressed form.
+     * @param p The point to serialize.
+     * @return prefix The prefix byte (0x02 or 0x03).
+     * @return encoded The encoded x-coordinate.
+     */
+    function serialize(Point memory p) internal pure returns (uint8 prefix, bytes32 encoded) {
+        requireNonZero(p);
+        uint256 y = p.y;
+        assembly ("memory-safe") {
+            prefix := add(2, and(y, 1))
+        }
+        encoded = bytes32(p.x);
+    }
+
+    // ============================================================
+    // PRIVATE FUNCTIONS
+    // ============================================================
+
+    /**
+     * @notice Unpacks a point and validates it is on the curve or zero.
+     * @param p The point to unpack.
+     * @return x The x-coordinate.
+     * @return y The y-coordinate.
+     */
+    function _unpack(Point memory p) private pure returns (uint256 x, uint256 y) {
+        x = p.x;
+        y = p.y;
+        bool valid = _satisfiesCurveEquation(x, y);
+        assembly ("memory-safe") {
+            valid := or(iszero(or(x, y)), valid)
+        }
+        require(valid, NotOnCurve());
+    }
+
+    /**
+     * @notice Checks if coordinates satisfy the curve equation y² = x³ + b.
+     * @param x The x-coordinate.
+     * @param y The y-coordinate.
+     * @return result True if the coordinates satisfy the curve equation.
+     */
+    function _satisfiesCurveEquation(uint256 x, uint256 y) private pure returns (bool result) {
+        assembly ("memory-safe") {
+            // Check (branchlessly) that the point's coordinates satisfy the curve equation:
+            //      Py² = Px³ + b
+            // And that both `Px` and `Py` are elements in Fp.
+            result := and(eq(mulmod(y, y, P), addmod(mulmod(x, mulmod(x, x, P), P), B, P)), and(lt(x, P), lt(y, P)))
+        }
+    }
+
+    /**
+     * @notice Computes division in a prime field using Fermat's little theorem.
+     * @param x The dividend.
+     * @param y The divisor.
+     * @param p The prime modulus.
+     * @return result The result of x / y mod p.
+     * @dev Division in a prime field is defined as multiplication by the divisor's multiplicative inverse. The most
+     *      efficient way to compute a multiplicative inverse on the EVM is by applying Fermat's little theorem, which
+     *      implies that `inv(y) = y ** (p - 2)  (mod p)` is the multiplicative inverse of `y` (where
+     *      `inv(y) * y = 1  (mod p)`). We use the `modexp (0x05)` precompile for computing this. The use of assembly
+     *      is required, as there is no `modexp` built-in in Solidity.
+     */
+    function _divmod(uint256 x, uint256 y, uint256 p) private view returns (uint256 result) {
+        bool success;
+        assembly ("memory-safe") {
+            // Call `modexp(32, 32, 32, y, p - 2, p)`, where 32 is the size in bytes of the base, exponent, and modulo.
+            // The result is `inv(y)`, the multiplicative inverse of `y`.
+            let ptr := mload(0x40)
+            mstore(ptr, 0x20)
+            mstore(add(ptr, 0x20), 0x20)
+            mstore(add(ptr, 0x40), 0x20)
+            mstore(add(ptr, 0x60), y)
+            mstore(add(ptr, 0x80), sub(p, 2))
+            mstore(add(ptr, 0xa0), p)
+            success := and(eq(returndatasize(), 0x20), staticcall(gas(), 0x5, ptr, 0xc0, 0x00, 0x20))
+
+            // Compute `x / y = x * inv(y)`.
+            result := mulmod(x, mload(0x00), p)
+        }
+        assert(success);
+    }
+}

--- a/contracts/libraries/SignatureExtension.sol
+++ b/contracts/libraries/SignatureExtension.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.30;
 /**
  * @title SignatureExtension
  * @notice A reusable format for appending typed, variable-length data after a Safe's owner signatures.
- * @dev Vendored from `safe-research/safenet` at commit
- *      `1b3c9422600a03d69c4048a160d39b0e32401f28`, path
- *      `contracts/src/libraries/SignatureExtension.sol`. Keep the two in sync.
+ * @dev Vendored from `safe-research/safenet` at `5de7e86900b27844d00458d8dc85cbaa0d27f2ea`,
+ *      `contracts/src/libraries/SignatureExtension.sol`. The body is verbatim; only this note and
+ *      the licence header differ, which `npm run vendor:check` enforces.
  *
  *      A *signature extension* is a self-describing envelope appended to Safe's `signatures` bytes.
  *      Safe's own signature parser reads owner signatures front-to-back and ignores trailing bytes, so a
@@ -34,17 +34,29 @@ pragma solidity ^0.8.30;
  *      nesting is not supported (a future need would be a new format/version).
  */
 library SignatureExtension {
+    // ============================================================
+    // CONSTANTS
+    // ============================================================
+
     /**
      * @dev Fixed envelope overhead: the `uint256 payloadLength` word (32 bytes) plus the terminal
      *      `bytes32 typeHash` word (32 bytes).
      */
     uint256 private constant _ENVELOPE_OVERHEAD = 64;
 
+    // ============================================================
+    // ERRORS
+    // ============================================================
+
     /**
      * @notice Thrown when a blob carries the expected type hash but is not a well-formed envelope — too
      *         short to hold `[payloadLength][typeHash]`, or a payload length that runs past the front.
      */
     error MalformedSignatureExtension();
+
+    // ============================================================
+    // INTERNAL FUNCTIONS
+    // ============================================================
 
     /**
      * @notice Returns whether `signatures` carries an extension of type `typeHash` (ends with it).

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -40,9 +40,10 @@ const config: HardhatUserConfig = {
       {
         version: '0.8.30',
         settings: {
-          // Pinned explicitly: this is Hardhat's current default, but relying on the default would
-          // let a Hardhat upgrade silently change the deployed bytecode.
-          evmVersion: 'paris',
+          // Pinned explicitly rather than left to the Hardhat default, so a Hardhat upgrade cannot
+          // silently change the deployed bytecode. `cancun` is required by the vendored Safenet
+          // libraries, which use `mcopy`; it rules out chains that have not activated Cancun.
+          evmVersion: 'cancun',
           optimizer: {
             enabled: true,
             runs: 10_000_000

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:fix:ts": "eslint --fix",
     "test": "hardhat test --network hardhat --grep '^(?!.*\\[@bench\\])'",
     "test:bench": "hardhat test --network hardhat --grep '\\[@bench\\]'",
+    "vendor:check": "ts-node script/check-vendored.ts",
     "coverage": "hardhat coverage",
     "verify": "hardhat etherscan-verify --force-license --license LGPL-3.0 --network"
   },

--- a/script/check-vendored.ts
+++ b/script/check-vendored.ts
@@ -1,0 +1,142 @@
+/**
+ * Verifies that the vendored `safe-research/safenet` sources still match upstream.
+ *
+ * Each vendored file records the commit it came from in its own header. This script re-downloads
+ * that exact commit, replays the documented transformation, and diffs the result against what is on
+ * disk. It therefore catches both directions of drift: a local edit that was never sent upstream,
+ * and a header that claims a commit its contents do not correspond to.
+ *
+ * Run with `npm run vendor:check`. Requires network access to raw.githubusercontent.com.
+ */
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const RAW_BASE = 'https://raw.githubusercontent.com/safe-research/safenet'
+
+/**
+ * How a vendored file is compared against upstream.
+ *
+ * - `full`: the local file is reproducible from upstream by replaying the transformation, so every
+ *   byte is compared, doc comments included.
+ * - `code`: only the declaration onwards is compared. Used where the leading comment block was
+ *   deliberately rewritten for this package and cannot be reconstructed.
+ */
+type Comparison = 'full' | 'code'
+
+type Vendored = {
+  local: string
+  upstream: string
+  comparison: Comparison
+}
+
+const VENDORED: Vendored[] = [
+  { local: 'contracts/libraries/Secp256k1.sol', upstream: 'Secp256k1.sol', comparison: 'full' },
+  { local: 'contracts/libraries/FROST.sol', upstream: 'FROST.sol', comparison: 'full' },
+  { local: 'contracts/libraries/ConsensusMessages.sol', upstream: 'ConsensusMessages.sol', comparison: 'full' },
+  { local: 'contracts/libraries/EpochRollover.sol', upstream: 'EpochRollover.sol', comparison: 'full' },
+  // The vendoring note in this one's NatSpec was rewritten by hand, so only the library body is
+  // reproducible from upstream.
+  {
+    local: 'contracts/libraries/SignatureExtension.sol',
+    upstream: 'SignatureExtension.sol',
+    comparison: 'code'
+  }
+]
+
+/** Extracts the 40-hex upstream commit a vendored file claims to come from. */
+function commitOf(source: string, local: string): string {
+  const match = source.match(/\b([0-9a-f]{40})\b/)
+  if (!match) {
+    throw new Error(`${local}: no upstream commit found in the vendoring header`)
+  }
+  return match[1]
+}
+
+/**
+ * Replays the transformation applied when vendoring: the licence header is relabelled to this
+ * package's, and the Foundry `@/libraries/` remapping is rewritten to a relative path.
+ */
+function transform(upstream: string): string {
+  return upstream
+    .replace('// SPDX-License-Identifier: GPL-3.0-only\n', '// SPDX-License-Identifier: LGPL-3.0-only\n')
+    .replace(/from "@\/libraries\//g, 'from "./')
+}
+
+/** Drops everything before the top-level declaration, leaving the body to compare. */
+function codeOnly(source: string): string {
+  const match = source.match(/^(library|contract|interface|abstract contract) /m)
+  if (!match || match.index === undefined) {
+    throw new Error('no top-level declaration found')
+  }
+  return source.slice(match.index)
+}
+
+/**
+ * Removes the provenance block this repo inserts after the pragma, so the remainder lines up with
+ * upstream. The block is the run of `//` comments introduced by the "Vendored from" line.
+ */
+function stripProvenance(local: string): string {
+  const lines = local.split('\n')
+  const start = lines.findIndex((line) => line.startsWith('// Vendored from'))
+  if (start === -1) {
+    return local
+  }
+  let end = start
+  while (end < lines.length && lines[end].startsWith('//')) {
+    end++
+  }
+  // The inserted block is preceded by a blank line that was not in upstream.
+  const from = start > 0 && lines[start - 1] === '' ? start - 1 : start
+  lines.splice(from, end - from)
+  return lines.join('\n')
+}
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12)
+}
+
+async function fetchUpstream(commit: string, upstream: string): Promise<string> {
+  const url = `${RAW_BASE}/${commit}/contracts/src/libraries/${upstream}`
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`${url}: HTTP ${response.status}`)
+  }
+  return await response.text()
+}
+
+async function main(): Promise<void> {
+  const failures: string[] = []
+
+  for (const { local, upstream, comparison } of VENDORED) {
+    const onDisk = await readFile(join(process.cwd(), local), 'utf-8')
+    const commit = commitOf(onDisk, local)
+    const fromUpstream = transform(await fetchUpstream(commit, upstream))
+
+    const [actual, expected] =
+      comparison === 'full' ? [stripProvenance(onDisk), fromUpstream] : [codeOnly(onDisk), codeOnly(fromUpstream)]
+
+    if (actual === expected) {
+      console.log(`  ok  ${local}  (${commit.slice(0, 10)}, ${comparison})`)
+    } else {
+      failures.push(local)
+      console.log(`FAIL  ${local}  (${commit.slice(0, 10)}, ${comparison})`)
+      console.log(`      local ${digest(actual)} != upstream ${digest(expected)}`)
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(
+      `\n${failures.length} vendored file(s) diverge from upstream. Either re-vendor from the ` +
+        `recorded commit, or update the commit in the file header if the change was intentional.`
+    )
+    process.exit(1)
+  }
+
+  console.log(`\nAll ${VENDORED.length} vendored files match upstream.`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": ["./hardhat.config.ts", "./deploy/**/*", "./test/**/*", "./src/**/*", "./lib/**/*"]
+  "include": ["./hardhat.config.ts", "./deploy/**/*", "./script/**/*", "./test/**/*", "./src/**/*", "./lib/**/*"]
 }


### PR DESCRIPTION
## Context and Motivation

`SafenetPolicy`, added in the next commit, verifies FROST threshold signatures. That needs `safe-research/safenet`'s `Secp256k1`, `FROST`, `ConsensusMessages` and `EpochRollover`. They land here on their own so the vendored code is reviewable separately from the policy that consumes it — nothing imports them yet.

Consuming safenet as a dependency was investigated and is not currently possible: the repository has no `package.json`, so it cannot be installed from npm or git, and its sources import through the Foundry remapping `@/=src/`, which Hardhat 2 cannot resolve. Neither blocker is ours to remove.

## Decisions and Tradeoffs

`evmVersion` moves from `paris` to `cancun`, which `FROST` and `ConsensusMessages` require — both use `mcopy`, and solc rejects it outright on an earlier target. This is the one irreversible consequence of the Safenet work: chains that have not activated Cancun stop being deployment targets. It is confined to this commit and the next so that dropping them restores full chain coverage. The Safe fixture overrides stay on `paris` and 0.8.28.

The files are byte-identical to upstream apart from the licence header, relabelled to this package's LGPL-3.0-only — a deliberate relicensing decision, both repositories being ours — and the `@/libraries/` import alias rewritten to a relative path.

`npm run vendor:check` re-downloads each file at the commit recorded in that file's own header, replays those two transformations, and diffs. It therefore catches a local edit and a stale pin alike, and runs in CI. `.solhintignore` and `.prettierignore` stop prettier reformatting vendored sources, which would make them undiffable against upstream; both are needed, since `lint:fix:sol` invokes prettier directly as well as through solhint.

The check found a pre-existing defect on its first run: `SignatureExtension.sol` had three section comments stripped by prettier while its header claimed the file was identical to upstream. The body is restored and the pin unified to the commit the other four come from, where the file is unchanged.

Coverage skips all five, naming upstream's own unit tests under `contracts/test/libraries/`.

## Testing

Full gate on the Cancun target: build clean, lint clean, 134 passing, `vendor:check` reporting all five files matching upstream. The check was confirmed to fail on a one-word edit to a vendored comment.