### PR TITLE
Emit event on one time allowance usage

### DIFF
--- a/contracts/policies/ERC20ApprovePolicy.sol
+++ b/contracts/policies/ERC20ApprovePolicy.sol
@@ -54,6 +54,20 @@ contract ERC20ApprovePolicy is IPolicy {
      */
     error InvalidOperation();
 
+    /**
+     * @notice Emitted when an approval spends a single-use permission recorded for a spender.
+     * @param policyGuard The policy guard whose namespace the permission belongs to.
+     * @param safe The Safe address.
+     * @param token The token address.
+     * @param spender The spender address.
+     */
+    event SpenderPermissionUsed(
+        address indexed policyGuard,
+        address indexed safe,
+        address indexed token,
+        address spender
+    );
+
     function checkTransaction(
         address safe,
         address to,
@@ -72,6 +86,7 @@ contract ERC20ApprovePolicy is IPolicy {
             require(permission != Permission.NONE, Unauthorized());
             if (permission == Permission.ONCE) {
                 delete $spenders[msg.sender][safe][token][spender];
+                emit SpenderPermissionUsed(msg.sender, safe, token, spender);
             }
         }
         return IPolicy.checkTransaction.selector;

--- a/contracts/policies/ERC20TransferPolicy.sol
+++ b/contracts/policies/ERC20TransferPolicy.sol
@@ -54,6 +54,20 @@ contract ERC20TransferPolicy is IPolicy {
      */
     error InvalidOperation();
 
+    /**
+     * @notice Emitted when a transfer spends a single-use permission recorded for a recipient.
+     * @param policyGuard The policy guard whose namespace the permission belongs to.
+     * @param safe The Safe address.
+     * @param token The token address.
+     * @param recipient The recipient address.
+     */
+    event RecipientPermissionUsed(
+        address indexed policyGuard,
+        address indexed safe,
+        address indexed token,
+        address recipient
+    );
+
     function checkTransaction(
         address safe,
         address to,
@@ -70,6 +84,7 @@ contract ERC20TransferPolicy is IPolicy {
         require(permission != Permission.NONE, Unauthorized());
         if (permission == Permission.ONCE) {
             delete $recipients[msg.sender][safe][token][recipient];
+            emit RecipientPermissionUsed(msg.sender, safe, token, recipient);
         }
         return IPolicy.checkTransaction.selector;
     }

--- a/contracts/policies/OneTimeAllowPolicy.sol
+++ b/contracts/policies/OneTimeAllowPolicy.sol
@@ -29,9 +29,6 @@ contract OneTimeAllowPolicy is IPolicy {
      * @param policyGuard The policy guard whose namespace the allowance belonged to.
      * @param safe The Safe address.
      * @param access The access selector.
-     * @dev The allowance is always cleared by a successful check. A
-     *      {configure} write is not reported here; the guard logs configuration through its own
-     *      events, so reconstructing the allowance needs both sources.
      */
     event OneTimeAllowanceUsed(address indexed policyGuard, address indexed safe, AccessSelector.T indexed access);
 

--- a/contracts/policies/OneTimeAllowPolicy.sol
+++ b/contracts/policies/OneTimeAllowPolicy.sol
@@ -25,6 +25,17 @@ contract OneTimeAllowPolicy is IPolicy {
     error Unauthorized();
 
     /**
+     * @notice Emitted when a transaction spends the one-time allowance for an access selector.
+     * @param policyGuard The policy guard whose namespace the allowance belonged to.
+     * @param safe The Safe address.
+     * @param access The access selector.
+     * @dev The allowance is always cleared by a successful check. A
+     *      {configure} write is not reported here; the guard logs configuration through its own
+     *      events, so reconstructing the allowance needs both sources.
+     */
+    event OneTimeAllowanceUsed(address indexed policyGuard, address indexed safe, AccessSelector.T indexed access);
+
+    /**
      * @inheritdoc IPolicy
      * @dev Spends the grant, so a batch replaying the same sub-transaction is allowed exactly once.
      */
@@ -40,6 +51,7 @@ contract OneTimeAllowPolicy is IPolicy {
     ) external override returns (bytes4 magicValue) {
         require($grants[msg.sender][safe][access], Unauthorized());
         delete $grants[msg.sender][safe][access];
+        emit OneTimeAllowanceUsed(msg.sender, safe, access);
         return IPolicy.checkTransaction.selector;
     }
 

--- a/test/erc20ApprovePolicy.spec.ts
+++ b/test/erc20ApprovePolicy.spec.ts
@@ -355,4 +355,100 @@ describe('ERC20ApprovePolicy', function () {
       )
     })
   })
+
+  describe('Events', function () {
+
+    it('Should emit when an approval spends a one-time grant', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      const spender = randomAddress()
+
+      await enableGuard({
+        owners: [owner],
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target: await token.getAddress(),
+            selector: token.interface.getFunction('approve').selector,
+            policy: await erc20ApprovePolicy.getAddress(),
+            data: encodeAllowlistConfig([spender], Permission.Once)
+          })
+        ]
+      })
+
+      // Spending the grant removes the spender from the allowlist, which an indexer only learns
+      // about from this event -- the guard emits nothing for a transaction it permits.
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await token.getAddress(),
+          data: token.interface.encodeFunctionData('approve', [spender, ethers.parseEther('100')])
+        })
+      )
+        .to.emit(erc20ApprovePolicy, 'SpenderPermissionUsed')
+        .withArgs(safePolicyGuard, safe, token, spender)
+    })
+
+    it('Should not emit when an approval leaves the allowlist unchanged', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      const spender = randomAddress()
+
+      await enableGuard({
+        owners: [owner],
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target: await token.getAddress(),
+            selector: token.interface.getFunction('approve').selector,
+            policy: await erc20ApprovePolicy.getAddress(),
+            data: encodeAllowlistConfig([spender], Permission.Always)
+          })
+        ]
+      })
+
+      // An open-ended grant is not spent, so there is no state change to report.
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await token.getAddress(),
+          data: token.interface.encodeFunctionData('approve', [spender, ethers.parseEther('100')])
+        })
+      ).to.not.emit(erc20ApprovePolicy, 'SpenderPermissionUsed')
+    })
+
+    it('Should not emit when a zero-amount approval bypasses the allowlist', async function () {
+      const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
+
+      const spender = randomAddress()
+
+      await enableGuard({
+        owners: [owner],
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target: await token.getAddress(),
+            selector: token.interface.getFunction('approve').selector,
+            policy: await erc20ApprovePolicy.getAddress(),
+            data: encodeAllowlistConfig([spender], Permission.Once)
+          })
+        ]
+      })
+
+      // Revoking an allowance never touches the grant, so the indexed state stays put.
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await token.getAddress(),
+          data: token.interface.encodeFunctionData('approve', [spender, 0])
+        })
+      ).to.not.emit(erc20ApprovePolicy, 'SpenderPermissionUsed')
+    })
+  })
 })

--- a/test/erc20ApprovePolicy.spec.ts
+++ b/test/erc20ApprovePolicy.spec.ts
@@ -357,7 +357,6 @@ describe('ERC20ApprovePolicy', function () {
   })
 
   describe('Events', function () {
-
     it('Should emit when an approval spends a one-time grant', async function () {
       const { owner, safePolicyGuard, safe, erc20ApprovePolicy, token } = await loadFixture(fixture)
 

--- a/test/erc20TransferPolicy.spec.ts
+++ b/test/erc20TransferPolicy.spec.ts
@@ -372,4 +372,69 @@ describe('ERC20TransferPolicy', function () {
       )
     })
   })
+
+  describe('Events', function () {
+    it('Should emit when a transfer spends a one-time grant', async function () {
+      const { owner, recipient, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      const recipientAddress = await recipient.getAddress()
+
+      await enableGuard({
+        owners: [owner],
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target: await token.getAddress(),
+            selector: token.interface.getFunction('transfer').selector,
+            policy: await erc20TransferPolicy.getAddress(),
+            data: encodeAllowlistConfig([recipientAddress], Permission.Once)
+          })
+        ]
+      })
+
+      // Spending the grant removes the recipient from the allowlist, which an indexer only learns
+      // about from this event -- the guard emits nothing for a transaction it permits.
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await token.getAddress(),
+          data: token.interface.encodeFunctionData('transfer', [recipientAddress, ethers.parseEther('100')])
+        })
+      )
+        .to.emit(erc20TransferPolicy, 'RecipientPermissionUsed')
+        .withArgs(safePolicyGuard, safe, token, recipientAddress)
+    })
+
+    it('Should not emit when a transfer leaves the allowlist unchanged', async function () {
+      const { owner, recipient, safePolicyGuard, safe, erc20TransferPolicy, token } = await loadFixture(fixture)
+
+      const recipientAddress = await recipient.getAddress()
+
+      await enableGuard({
+        owners: [owner],
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target: await token.getAddress(),
+            selector: token.interface.getFunction('transfer').selector,
+            policy: await erc20TransferPolicy.getAddress(),
+            data: encodeAllowlistConfig([recipientAddress], Permission.Always)
+          })
+        ]
+      })
+
+      // An open-ended grant is not spent, so there is no state change to report.
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: await token.getAddress(),
+          data: token.interface.encodeFunctionData('transfer', [recipientAddress, ethers.parseEther('100')])
+        })
+      ).to.not.emit(erc20TransferPolicy, 'RecipientPermissionUsed')
+    })
+  })
 })

--- a/test/oneTimeAllowPolicy.spec.ts
+++ b/test/oneTimeAllowPolicy.spec.ts
@@ -210,4 +210,39 @@ describe('OneTimeAllowPolicy', function () {
       await expect(oneTimeAllowPolicy.connect(deployer).configure(safe, access, '0x')).to.be.reverted
     })
   })
+
+  describe('Events', function () {
+    it('Should emit when a transaction spends the allowance', async function () {
+      const { owner, safePolicyGuard, safe, oneTimeAllowPolicy, accessSelector } = await loadFixture(fixture)
+
+      const target = randomAddress()
+      const access = await accessSelector.create(target, '0x00000000', SafeOperation.Call)
+
+      await enableGuard({
+        owners: [owner],
+        safe,
+        safePolicyGuard,
+        configurations: [
+          createConfiguration({
+            target,
+            policy: await oneTimeAllowPolicy.getAddress(),
+            data: encodeOneTimeGrantConfig()
+          })
+        ]
+      })
+
+      // Spending the grant revokes it, which an indexer only learns about from this event -- the
+      // guard emits nothing for a transaction it permits.
+      await expect(
+        execTransaction({
+          owners: [owner],
+          safe,
+          to: target,
+          value: ethers.parseEther('1')
+        })
+      )
+        .to.emit(oneTimeAllowPolicy, 'OneTimeAllowanceUsed')
+        .withArgs(safePolicyGuard, safe, access)
+    })
+  })
 })


### PR DESCRIPTION
This pull request adds new events and corresponding tests to improve observability of one-time permission usage in the `ERC20ApprovePolicy`, `ERC20TransferPolicy`, and `OneTimeAllowPolicy` contracts. These events make it easier for indexers and off-chain systems to track when single-use allowances are consumed, as the guards themselves do not emit events on permission change.

 No need to emit event on `configure` as `SafePolicyGuard` contract emits the `PolicyConfirmed` event already which contains the data about policy changes.